### PR TITLE
draft-tjson-examples.txt: Test fixtures for compliant TJSON parsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+sudo: false
+
+rvm:
+  - 2.2
+
+branches:
+  only:
+    - master

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "rake"
+gem "toml-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    citrus (3.0.2)
+    rake (11.3.0)
+    toml-rb (0.3.14)
+      citrus (~> 3.0, > 3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  toml-rb
+
+BUNDLED WITH
+   1.13.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,69 @@
+require "bundler/setup"
+
+TJSON_EXAMPLES = Pathname("draft-tjson-examples.txt")
+MANDATORY_KEYS = %w(name description result)
+
+namespace :examples do
+  task :verify do
+    require "toml"
+    require "json"
+
+    examples_text = TJSON_EXAMPLES.read
+
+    # Strip comments
+    examples_text.gsub!(/^#.*?$/m, "")
+
+    examples = examples_text.split(/^-----$/m)
+
+    # This is supposed to be blank
+    first_example = examples.shift
+
+    unless first_example =~ (/\A\s*\z/)
+      fail "Unexpected data before leading '-----': #{first_example.inspect}"
+    end
+
+    # This is also supposed to be blank
+    last_example = examples.pop
+
+    unless last_example =~ (/\A\s*\z/)
+      fail "Unexpected data before trailing '-----': #{last_example.inspect}"
+    end
+
+    examples.each_with_index do |example, number|
+      metadata_text, example_text, extra = example.split(/^%%%$/m)
+      fail "Error parsing header of example \##{number + 1}: extra '%%%'" unless extra.nil?
+
+      # Strip leading newline from metadata
+      metadata_text.sub!(/\A\n/m, "")
+
+      begin
+        metadata = TOML.parse(metadata_text)
+      rescue TOML::ParseError => ex
+        fail "Error parsing header of example \##{number + 1}: #{ex.message}"
+      end
+
+      metadata.each do |key, _value|
+        fail "Unknown key in metadata: #{key} (example \##{number + 1})" unless MANDATORY_KEYS.include?(key)
+      end
+
+      MANDATORY_KEYS.each do |key|
+        fail "Missing mandatory key from metadata: #{key} (example \##{number + 1})" unless metadata.key?(key)
+      end
+
+      result_type = metadata["result"]
+      fail "Bad result type: #{result_type.inspect} (example \##{number + 1})" unless %w(success error).include?(result_type)
+
+      if result_type == "success"
+        begin
+          JSON.parse(example_text)
+        rescue JSON::ParserError => ex
+          fail "Error parsing example \##{number + 1} as JSON: #{ex.message}"
+        end
+      end
+    end
+
+    puts "Success! Example file '#{TJSON_EXAMPLES}' is valid."
+  end
+end
+
+task default: %w(examples:verify)

--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -1,0 +1,36 @@
+#
+# [DRAFT] Annotated TJSON examples intended for testing TJSON parsers
+#
+# Revision: 0 (bump this when making changes to this file)
+#
+# Syntax used in this file:
+#
+# - Any line beginning with a '#' is a comment and should be ignored
+# - Examples are delimited by a line containing only '-----' (5 hyphen characters)
+# - This file should begin/end with '-----' with only comments allowed before/after
+#   the leading and trailing '-----' respectively (i.e. this comment block)
+# - Each example consists of TOML metadata and an example, separated by '%%%'
+#
+# Example metadata syntax:
+#
+# - name = "Name of this example"
+# - description = "A more extended description of what this example tests"
+# - result = "success" | "error"
+#
+-----
+name = "Empty Array"
+description = "Arrays are allowed as a toplevel value and can be empty"
+result = "success"
+%%%
+
+[]
+
+-----
+name = "Empty Object"
+description = "Objects are allowed as a toplevel value and can be empty"
+result = "success"
+%%%
+
+{}
+
+-----


### PR DESCRIPTION
This file contains a set of standard examples that can be used for automated tests of TJSON parsers.

Ideally this file gets updated along with draft-tjson-spec.md

Includes a rudimentary Ruby-based test harness to check for basic formatting errors, which can run on Travis CI.
