### PR TITLE
Integers and Floats

### DIFF
--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -146,3 +146,44 @@ result = "error"
 ["b16:This is not a valid base64url string"]
 
 -----
+name = "Integer"
+description = "Integers are represented as tagged strings"
+result = "success"
+%%%
+
+["i:42"]
+
+-----
+name = "Integer Range Test"
+description = "It should be possible to represent the full range of a signed 64-bit integer"
+result = "success"
+%%%
+
+["i:−9223372036854775808", "i:9223372036854775807"]
+
+-----
+name = "Oversized Integer Test"
+description = "Values larger than can be represented by a signed 64-bit integer should be rejected"
+result = "error"
+%%%
+
+["i:9223372036854775808"]
+
+-----
+name = "Undersized Integer Test"
+description = "Values smaller than can be represented by a signed 64-bit integer should be rejected"
+result = "error"
+%%%
+
+["i:−9223372036854775809"]
+
+-----
+
+name = "Invalid Integer"
+description = "Garbage data after the integer tag should be rejected"
+result = "error"
+%%%
+
+["i:This is not a valid integer"]
+
+-----

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -155,4 +155,24 @@ This should decode to the equivalent of the ASCII string: "Hello, world!"
 Only the base64url format is supported. The non-URL safe form of base64
 is not supported and MUST be rejected by parsers.
 
+## Integers ("i:")
+
+TJSON provides a standard syntax for representing integers as tagged strings,
+which allows representing more than the `[-(2**53)+1, (2**53)-1]` range of
+integers defined as interoperable in [@!RFC7159].
+
+An integer literal tagged string starts with the "i:" tag, followed by a
+valid JSON integer literal, with an optional minus character.
+
+Conforming TJSON parsers MUST be capable of supporting the full integer range
+`[−(2**63), (2**63)−1]`, i.e. the range of a signed 64-bit integer.
+
+Integers outside this range MUST be rejected.
+
+## Floating Points
+
+All numeric literals which are not represented as tagged strings MUST be
+treated as floating points under TJSON. This is already the default behavior
+of many JSON libraries.
+
 {backmatter}

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -62,16 +62,18 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
      1.1.  Conventions Used in This Document . . . . . . . . . . . .   2
-   2.  TJSON Grammar . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  TJSON Grammar . . . . . . . . . . . . . . . . . . . . . . . .   3
      2.1.  String Grammar  . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  Root Symbol . . . . . . . . . . . . . . . . . . . . . . .   3
-   3.  Extended Types  . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Extended Types  . . . . . . . . . . . . . . . . . . . . . . .   4
      3.1.  Unicode Strings ("u:")  . . . . . . . . . . . . . . . . .   4
      3.2.  Binary Data . . . . . . . . . . . . . . . . . . . . . . .   4
        3.2.1.  base16 ("b16:") . . . . . . . . . . . . . . . . . . .   4
-       3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   4
+       3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
+     3.3.  Integers ("i:") . . . . . . . . . . . . . . . . . . . . .   5
+     3.4.  Floating Points . . . . . . . . . . . . . . . . . . . . .   5
    4.  Normative References  . . . . . . . . . . . . . . . . . . . .   5
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   5
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   6
 
 1.  Introduction
 
@@ -101,10 +103,8 @@ Table of Contents
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in [RFC2119].
 
-2.  TJSON Grammar
 
-   TJSON relies on JSON as the basis of its grammar.  All TJSON
-   documents are valid JSON documents (however the reverse is not true).
+
 
 
 
@@ -114,6 +114,10 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 2]
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
 
+2.  TJSON Grammar
+
+   TJSON relies on JSON as the basis of its grammar.  All TJSON
+   documents are valid JSON documents (however the reverse is not true).
    The TJSON grammar can thus be seen as an extension of the JSON
    grammar, but one implemented in a backwards-compatible way.
 
@@ -154,11 +158,7 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    Documents which do not contain an object or array as the toplevel
    element MUST be rejected by parsers.
 
-3.  Extended Types
 
-   The following section describes the extended types added to TJSON by
-   embedding them in string literals as described in section 2.1 of this
-   document.
 
 
 
@@ -169,6 +169,12 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 3]
 
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
+
+3.  Extended Types
+
+   The following section describes the extended types added to TJSON by
+   embedding them in string literals as described in section 2.1 of this
+   document.
 
 3.1.  Unicode Strings ("u:")
 
@@ -210,13 +216,7 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    This should decode to the equivalent of the ASCII string: "Hello,
    world!"
 
-3.2.2.  base64url ("b64:")
 
-   A base64url literal starts with the "b64:" tag, followed by a valid
-   base64url string.  The base64url format is described in [RFC4648].
-   All base64url strings in TJSON MUST NOT include any padding with the
-   '=' character.  TJSON parsers MUST reject any documents containing
-   padded base64url strings.
 
 
 
@@ -225,6 +225,14 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 4]
 
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
+
+3.2.2.  base64url ("b64:")
+
+   A base64url literal starts with the "b64:" tag, followed by a valid
+   base64url string.  The base64url format is described in [RFC4648].
+   All base64url strings in TJSON MUST NOT include any padding with the
+   '=' character.  TJSON parsers MUST reject any documents containing
+   padded base64url strings.
 
    The following is an example of a base64url string literal in TJSON:
 
@@ -236,12 +244,43 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    Only the base64url format is supported.  The non-URL safe form of
    base64 is not supported and MUST be rejected by parsers.
 
+3.3.  Integers ("i:")
+
+   TJSON provides a standard syntax for representing integers as tagged
+   strings, which allows representing more than the "[-(2**53)+1,
+   (2**53)-1]" range of integers defined as interoperable in [RFC7159].
+
+   An integer literal tagged string starts with the "i:" tag, followed
+   by a valid JSON integer literal, with an optional minus character.
+
+   Conforming TJSON parsers MUST be capable of supporting the full
+   integer range "[-(2**63), (2**63)-1]", i.e. the range of a signed
+   64-bit integer.
+
+   Integers outside this range MUST be rejected.
+
+3.4.  Floating Points
+
+   All numeric literals which are not represented as tagged strings MUST
+   be treated as floating points under TJSON.  This is already the
+   default behavior of many JSON libraries.
+
 4.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <http://www.rfc-editor.org/info/rfc2119>.
+
+
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
+
+Internet-Draft        TJSON Data Interchange Format         October 2016
+
 
    [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
               10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
@@ -277,4 +316,21 @@ Authors' Addresses
 
 
 
-Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 6]

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -206,6 +206,28 @@ is not supported and MUST be rejected by parsers.
 </t>
 </section>
 </section>
+
+<section anchor="integers-i" title="Integers (&quot;i:&quot;)">
+<t>TJSON provides a standard syntax for representing integers as tagged strings,
+which allows representing more than the <spanx style="verb">[-(2**53)+1, (2**53)-1]</spanx> range of
+integers defined as interoperable in <xref target="RFC7159"/>.
+</t>
+<t>An integer literal tagged string starts with the &quot;i:&quot; tag, followed by a
+valid JSON integer literal, with an optional minus character.
+</t>
+<t>Conforming TJSON parsers MUST be capable of supporting the full integer range
+<spanx style="verb">[−(2**63), (2**63)−1]</spanx>, i.e. the range of a signed 64-bit integer.
+</t>
+<t>Integers outside this range MUST be rejected.
+</t>
+</section>
+
+<section anchor="floating-points" title="Floating Points">
+<t>All numeric literals which are not represented as tagged strings MUST be
+treated as floating points under TJSON. This is already the default behavior
+of many JSON libraries.
+</t>
+</section>
 </section>
 
 </middle>


### PR DESCRIPTION
Adds a spec for signed 64-bit integers represented as tagged strings. Allowed range is the same as a signed 64-bit integer. Overflowing and underflowing values are expressly disallowed.

Expressly calls out numeric literals should be treated as floats.

No specification for unsigned integers given yet.
