### PR TITLE
Objects

### DIFF
--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -34,6 +34,38 @@ result = "success"
 {}
 
 -----
+name = "Object with Unicode String Key"
+description = "Strings are allowed as names of object members"
+result = "success"
+%%%
+
+{"u:foo":"u:bar"}
+
+-----
+name = "Object with Binary Data Key"
+description = "Binary Data is allowed as the name of an object member"
+result = "success"
+%%%
+
+{"b16:48656c6c6f2c20776f726c6421":"u:foobar"}
+
+-----
+name = "Invalid Object with Bare String Key"
+description = "All strings in TJSON must be tagged"
+result = "error"
+%%%
+
+{"foo":"u:bar"}
+
+-----
+name = "Invalid Object with Integer Key"
+description = "Only Unicode Strings and Binary Data are allowed as names of object members"
+result = "error"
+%%%
+
+{"i:42":"u:foobar"}
+
+-----
 name = "Bare String"
 description = "Toplevel elements other than object or array are disallowed"
 result = "error"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -169,6 +169,18 @@ Conforming TJSON parsers MUST be capable of supporting the full integer range
 
 Integers outside this range MUST be rejected.
 
+# Handling of JSON types
+
+Below are notes about how the processing of certain JSON types should be
+handled under TJSON.
+
+## Objects
+
+TJSON constrains the allowable types for the names of object members to either
+Unicode Strings or Binary Data.
+
+All other types, such as integers, are expressly disallowed.
+
 ## Floating Points
 
 All numeric literals which are not represented as tagged strings MUST be

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -71,8 +71,10 @@ Table of Contents
        3.2.1.  base16 ("b16:") . . . . . . . . . . . . . . . . . . .   4
        3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
      3.3.  Integers ("i:") . . . . . . . . . . . . . . . . . . . . .   5
-     3.4.  Floating Points . . . . . . . . . . . . . . . . . . . . .   5
-   4.  Normative References  . . . . . . . . . . . . . . . . . . . .   5
+   4.  Handling of JSON types  . . . . . . . . . . . . . . . . . . .   5
+     4.1.  Objects . . . . . . . . . . . . . . . . . . . . . . . . .   5
+     4.2.  Floating Points . . . . . . . . . . . . . . . . . . . . .   6
+   5.  Normative References  . . . . . . . . . . . . . . . . . . . .   6
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   6
 
 1.  Introduction
@@ -102,8 +104,6 @@ Table of Contents
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in [RFC2119].
-
-
 
 
 
@@ -259,18 +259,18 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
    Integers outside this range MUST be rejected.
 
-3.4.  Floating Points
+4.  Handling of JSON types
 
-   All numeric literals which are not represented as tagged strings MUST
-   be treated as floating points under TJSON.  This is already the
-   default behavior of many JSON libraries.
+   Below are notes about how the processing of certain JSON types should
+   be handled under TJSON.
 
-4.  Normative References
+4.1.  Objects
 
-   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997,
-              <http://www.rfc-editor.org/info/rfc2119>.
+   TJSON constrains the allowable types for the names of object members
+   to either Unicode Strings or Binary Data.
+
+   All other types, such as integers, are expressly disallowed.
+
 
 
 
@@ -281,6 +281,19 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
 
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
+
+4.2.  Floating Points
+
+   All numeric literals which are not represented as tagged strings MUST
+   be treated as floating points under TJSON.  This is already the
+   default behavior of many JSON libraries.
+
+5.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
 
    [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
               10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
@@ -300,19 +313,6 @@ Authors' Addresses
 
 
    Ben Laurie
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -216,9 +216,23 @@ integers defined as interoperable in <xref target="RFC7159"/>.
 valid JSON integer literal, with an optional minus character.
 </t>
 <t>Conforming TJSON parsers MUST be capable of supporting the full integer range
-<spanx style="verb">[−(2**63), (2**63)−1]</spanx>, i.e. the range of a signed 64-bit integer.
+<spanx style="verb">[-(2**63), (2**63)-1]</spanx>, i.e. the range of a signed 64-bit integer.
 </t>
 <t>Integers outside this range MUST be rejected.
+</t>
+</section>
+</section>
+
+<section anchor="handling-of-json-types" title="Handling of JSON types">
+<t>Below are notes about how the processing of certain JSON types should be
+handled under TJSON.
+</t>
+
+<section anchor="objects" title="Objects">
+<t>TJSON constrains the allowable types for the names of object members to either
+Unicode Strings or Binary Data.
+</t>
+<t>All other types, such as integers, are expressly disallowed.
 </t>
 </section>
 


### PR DESCRIPTION
Places constraints on the types allowable as the names of members of objects, specifically restricting them to Unicode Strings or Binary Data.

Alternatively we could mandate that the names of members are always Unicode Strings, and potentially even omit the tag for this case, which would be visually appealing. However, future planned features such as redaction wouldn't work in this case, and binary data is potentially useful for naming members (e.g. cryptographic public keys or hash digests)
