### PR TITLE
Timestamps ("t:")

### DIFF
--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -169,6 +169,18 @@ Conforming TJSON parsers MUST be capable of supporting the full integer range
 
 Integers outside this range MUST be rejected.
 
+## Timestamps ("t:")
+
+TJSON natively supports a timestamp type whose syntax is a subset of that
+provided by [@!RFC3339]. Specifically, TJSON timestamps MUST use of the
+UTC time zone identifier "Z".
+
+The following is an example of a TJSON timestamp:
+
+    "t:2016-10-02T07:31:51Z"
+
+TJSON libraries SHOULD convert these timestamps to a native datetime type.
+
 # Handling of JSON types
 
 Below are notes about how the processing of certain JSON types should be

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -71,8 +71,9 @@ Table of Contents
        3.2.1.  base16 ("b16:") . . . . . . . . . . . . . . . . . . .   4
        3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
      3.3.  Integers ("i:") . . . . . . . . . . . . . . . . . . . . .   5
-   4.  Handling of JSON types  . . . . . . . . . . . . . . . . . . .   5
-     4.1.  Objects . . . . . . . . . . . . . . . . . . . . . . . . .   5
+     3.4.  Timestamps ("t:") . . . . . . . . . . . . . . . . . . . .   5
+   4.  Handling of JSON types  . . . . . . . . . . . . . . . . . . .   6
+     4.1.  Objects . . . . . . . . . . . . . . . . . . . . . . . . .   6
      4.2.  Floating Points . . . . . . . . . . . . . . . . . . . . .   6
    5.  Normative References  . . . . . . . . . . . . . . . . . . . .   6
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   6
@@ -104,7 +105,6 @@ Table of Contents
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in [RFC2119].
-
 
 
 
@@ -259,6 +259,29 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
    Integers outside this range MUST be rejected.
 
+3.4.  Timestamps ("t:")
+
+   TJSON natively supports a timestamp type whose syntax is a subset of
+   that provided by [RFC3339].  Specifically, TJSON timestamps MUST use
+   of the UTC time zone identifier "Z".
+
+   The following is an example of a TJSON timestamp:
+
+                         "t:2016-10-02T07:31:51Z"
+
+   TJSON libraries SHOULD convert these timestamps to a native datetime
+   type.
+
+
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
+
+Internet-Draft        TJSON Data Interchange Format         October 2016
+
+
 4.  Handling of JSON types
 
    Below are notes about how the processing of certain JSON types should
@@ -270,17 +293,6 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    to either Unicode Strings or Binary Data.
 
    All other types, such as integers, are expressly disallowed.
-
-
-
-
-
-
-
-Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
-
-Internet-Draft        TJSON Data Interchange Format         October 2016
-
 
 4.2.  Floating Points
 
@@ -294,6 +306,10 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
+              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
+              <http://www.rfc-editor.org/info/rfc3339>.
 
    [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
               10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
@@ -313,22 +329,6 @@ Authors' Addresses
 
 
    Ben Laurie
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -221,6 +221,21 @@ valid JSON integer literal, with an optional minus character.
 <t>Integers outside this range MUST be rejected.
 </t>
 </section>
+
+<section anchor="timestamps-t" title="Timestamps (&quot;t:&quot;)">
+<t>TJSON natively supports a timestamp type whose syntax is a subset of that
+provided by <xref target="RFC3339"/>. Specifically, TJSON timestamps MUST use of the
+UTC time zone identifier &quot;Z&quot;.
+</t>
+<t>The following is an example of a TJSON timestamp:
+</t>
+
+<figure align="center"><artwork align="center">
+"t:2016-10-02T07:31:51Z"
+</artwork></figure>
+<t>TJSON libraries SHOULD convert these timestamps to a native datetime type.
+</t>
+</section>
 </section>
 
 <section anchor="handling-of-json-types" title="Handling of JSON types">
@@ -248,6 +263,7 @@ of many JSON libraries.
 <back>
 <references title="Normative References">
 <?rfc include="http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"?>
+<?rfc include="http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3339.xml"?>
 <?rfc include="http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3629.xml"?>
 <?rfc include="http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4648.xml"?>
 <?rfc include="http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7159.xml"?>


### PR DESCRIPTION
Adds a timestamp type based on RFC3339.

Uses "t:" as the tag, unlike what presently appears on https://www.tjson.org (previously "d:" for datetime)
