### PR TITLE
Change UTF-8 String tag from "u:" -> "s:"

### DIFF
--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -34,12 +34,12 @@ result = "success"
 {}
 
 -----
-name = "Object with Unicode String Key"
+name = "Object with UTF-8 String Key"
 description = "Strings are allowed as names of object members"
 result = "success"
 %%%
 
-{"u:foo":"u:bar"}
+{"s:foo":"s:bar"}
 
 -----
 name = "Object with Binary Data Key"
@@ -47,7 +47,7 @@ description = "Binary Data is allowed as the name of an object member"
 result = "success"
 %%%
 
-{"b16:48656c6c6f2c20776f726c6421":"u:foobar"}
+{"b16:48656c6c6f2c20776f726c6421":"s:foobar"}
 
 -----
 name = "Invalid Object with Bare String Key"
@@ -55,15 +55,15 @@ description = "All strings in TJSON must be tagged"
 result = "error"
 %%%
 
-{"foo":"u:bar"}
+{"foo":"s:bar"}
 
 -----
 name = "Invalid Object with Integer Key"
-description = "Only Unicode Strings and Binary Data are allowed as names of object members"
+description = "Only UTF-8 Strings and Binary Data are allowed as names of object members"
 result = "error"
 %%%
 
-{"i:42":"u:foobar"}
+{"i:42":"s:foobar"}
 
 -----
 name = "Bare String"
@@ -71,23 +71,23 @@ description = "Toplevel elements other than object or array are disallowed"
 result = "error"
 %%%
 
-"u:hello, world!"
+"s:hello, world!"
 
 -----
-name = "Empty Unicode String"
-description = "An empty Unicode String is represented by a bare u: tag"
+name = "Empty UTF-8 String"
+description = "An empty UTF-8 String is represented by a bare s: tag"
 result = "success"
 %%%
 
-["u:"]
+["s:"]
 
 -----
-name = "Unicode String"
-description = "A Unicode String is always prefixed by a u: tag"
+name = "UTF-8 String"
+description = "A UTF-8 String is always prefixed by a s: tag"
 result = "success"
 %%%
 
-["u:hello, world!"]
+["s:hello, world!"]
 
 -----
 name = "Invalid Empty String"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -101,17 +101,17 @@ MUST be rejected by parsers.
 The following section describes the extended types added to TJSON by embedding
 them in string literals as described in section 2.1 of this document.
 
-## Unicode Strings ("u:")
+## UTF-8 Strings ("s:")
 
-The representation of Unicode Strings is grammatically identical to JSON,
-except per section 2.1 of this document strings of this type carry a
-mandatory tag character, "u:" indicating a Unicode String.
+The syntax for TJSON strings is grammatically identical to JSON, except per
+section 2.1 of this document the string type MUST carry a mandatory tag
+character, "s:" indicating a UTF-8 String. Unlike JSON, all Unicode Strings
+in TJSON MUST be valid UTF-8 [@!RFC3629]. Other Unicode encodings are
+expressly not supported.
 
-The following is an example of a Unicode String literal in TJSON:
+The following is an example of a UTF-8 String literal in TJSON:
 
-    "u:Hello, world!"
-
-Unlike JSON, all Unicode Strings in TJSON MUST be valid UTF-8 [@!RFC3629].
+    "s:Hello, world!"
 
 ## Binary Data
 

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -66,7 +66,7 @@ Table of Contents
      2.1.  String Grammar  . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  Root Symbol . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Extended Types  . . . . . . . . . . . . . . . . . . . . . . .   4
-     3.1.  Unicode Strings ("u:")  . . . . . . . . . . . . . . . . .   4
+     3.1.  UTF-8 Strings ("s:")  . . . . . . . . . . . . . . . . . .   4
      3.2.  Binary Data . . . . . . . . . . . . . . . . . . . . . . .   4
        3.2.1.  base16 ("b16:") . . . . . . . . . . . . . . . . . . .   4
        3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
@@ -176,18 +176,17 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    embedding them in string literals as described in section 2.1 of this
    document.
 
-3.1.  Unicode Strings ("u:")
+3.1.  UTF-8 Strings ("s:")
 
-   The representation of Unicode Strings is grammatically identical to
-   JSON, except per section 2.1 of this document strings of this type
-   carry a mandatory tag character, "u:" indicating a Unicode String.
+   The syntax for TJSON strings is grammatically identical to JSON,
+   except per section 2.1 of this document the string type MUST carry a
+   mandatory tag character, "s:" indicating a UTF-8 String.  Unlike
+   JSON, all Unicode Strings in TJSON MUST be valid UTF-8 [RFC3629].
+   Other Unicode encodings are expressly not supported.
 
-   The following is an example of a Unicode String literal in TJSON:
+   The following is an example of a UTF-8 String literal in TJSON:
 
-                             "u:Hello, world!"
-
-   Unlike JSON, all Unicode Strings in TJSON MUST be valid UTF-8
-   [RFC3629].
+                             "s:Hello, world!"
 
 3.2.  Binary Data
 
@@ -215,6 +214,7 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
    This should decode to the equivalent of the ASCII string: "Hello,
    world!"
+
 
 
 

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -143,19 +143,19 @@ MUST be rejected by parsers.
 them in string literals as described in section 2.1 of this document.
 </t>
 
-<section anchor="unicode-strings-u" title="Unicode Strings (&quot;u:&quot;)">
-<t>The representation of Unicode Strings is grammatically identical to JSON,
-except per section 2.1 of this document strings of this type carry a
-mandatory tag character, &quot;u:&quot; indicating a Unicode String.
+<section anchor="utf8-strings-s" title="UTF-8 Strings (&quot;s:&quot;)">
+<t>The syntax for TJSON strings is grammatically identical to JSON, except per
+section 2.1 of this document the string type MUST carry a mandatory tag
+character, &quot;s:&quot; indicating a UTF-8 String. Unlike JSON, all Unicode Strings
+in TJSON MUST be valid UTF-8 <xref target="RFC3629"/>. Other Unicode encodings are
+expressly not supported.
 </t>
-<t>The following is an example of a Unicode String literal in TJSON:
+<t>The following is an example of a UTF-8 String literal in TJSON:
 </t>
 
 <figure align="center"><artwork align="center">
-"u:Hello, world!"
+"s:Hello, world!"
 </artwork></figure>
-<t>Unlike JSON, all Unicode Strings in TJSON MUST be valid UTF-8 <xref target="RFC3629"/>.
-</t>
 </section>
 
 <section anchor="binary-data" title="Binary Data">


### PR DESCRIPTION
This changes the tag prefix used by UTF-8 strings to `"s:"`, freeing up `"u:"` for use as the tag prefix for unsigned integers.

See: https://github.com/tjson/tjson-spec/issues/12
