### PR TITLE
Unsigned Integers ("u:")

### DIFF
--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -178,15 +178,15 @@ result = "error"
 ["b16:This is not a valid base64url string"]
 
 -----
-name = "Integer"
-description = "Integers are represented as tagged strings"
+name = "Signed Integer"
+description = "Signed integers are represented as tagged strings"
 result = "success"
 %%%
 
 ["i:42"]
 
 -----
-name = "Integer Range Test"
+name = "Signed Integer Range Test"
 description = "It should be possible to represent the full range of a signed 64-bit integer"
 result = "success"
 %%%
@@ -194,28 +194,68 @@ result = "success"
 ["i:-9223372036854775808", "i:9223372036854775807"]
 
 -----
-name = "Oversized Integer Test"
-description = "Values larger than can be represented by a signed 64-bit integer should be rejected"
+name = "Oversized Signed Integer Test"
+description = "Values larger than can be represented by a signed 64-bit integer MUST be rejected"
 result = "error"
 %%%
 
 ["i:9223372036854775808"]
 
 -----
-name = "Undersized Integer Test"
-description = "Values smaller than can be represented by a signed 64-bit integer should be rejected"
+name = "Undersized Signed Integer Test"
+description = "Values smaller than can be represented by a signed 64-bit integer MUST be rejected"
 result = "error"
 %%%
 
 ["i:-9223372036854775809"]
 
 -----
-name = "Invalid Integer"
+name = "Invalid Signed Integer"
 description = "Garbage data after the integer tag should be rejected"
 result = "error"
 %%%
 
 ["i:This is not a valid integer"]
+
+-----
+name = "Unsigned Integer"
+description = "Unsigned integers are represented as tagged strings"
+result = "success"
+%%%
+
+["u:42"]
+
+-----
+name = "Unsigned Integer Range Test"
+description = "It should be possible to represent the full range of a signed 64-bit integer"
+result = "success"
+%%%
+
+["u:18446744073709551615"]
+
+-----
+name = "Oversized Unsigned Integer Test"
+description = "Values larger than can be represented by an unsigned 64-bit integer MUST be rejected"
+result = "error"
+%%%
+
+["u:18446744073709551616"]
+
+-----
+name = "Negative Unsigned Integer Test"
+description = "Unsigned integers cannot be negative"
+result = "error"
+%%%
+
+["u:-1"]
+
+-----
+name = "Invalid Unsigned Integer"
+description = "Garbage data after the integer tag should be rejected"
+result = "error"
+%%%
+
+["u:This is not a valid integer"]
 
 -----
 name = "Timestamp"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -155,19 +155,33 @@ This should decode to the equivalent of the ASCII string: "Hello, world!"
 Only the base64url format is supported. The non-URL safe form of base64
 is not supported and MUST be rejected by parsers.
 
-## Integers ("i:")
+## Integers
 
-TJSON provides a standard syntax for representing integers as tagged strings,
-which allows representing more than the `[-(2**53)+1, (2**53)-1]` range of
-integers defined as interoperable in [@!RFC7159].
+TJSON provides standard syntax for representing integers as tagged strings,
+which can express a larger range of values than the `[-(2**53)+1, (2**53)-1]`
+range defined as interoperable in [@!RFC7159].
 
-An integer literal tagged string starts with the "i:" tag, followed by a
-valid JSON integer literal, with an optional minus character.
+Both signed and unsigned integers are supported and provide the same ranges
+as 64-bit integers.
 
-Conforming TJSON parsers MUST be capable of supporting the full integer range
-`[-(2**63), (2**63)-1]`, i.e. the range of a signed 64-bit integer.
+### Signed Integers ("i:")
+
+A signed integer literal is represented as string with an "i:" tag, followed
+by a valid JSON integer literal, with an optional minus ("-") character.
+
+Conforming TJSON parsers MUST be capable of supporting the full 64-bit signed
+integer range `[-(2**63), (2**63)-1]` for this type.
 
 Integers outside this range MUST be rejected.
+
+### Unsigned Integers ("u:")
+
+An unsigned integer literal is represented as a string with a "u:" tag,
+followed by a valid JSON integer literal. The minus ("-") character is
+expressly disallowed and parsers MUST fail if it's present.
+
+Conforming TJSON parsers MUST be capable of supporting the full 64-bit unsigned
+integer range `[0, (2**64)−1]` for this type.
 
 ## Timestamps ("t:")
 

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -61,7 +61,7 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-     1.1.  Conventions Used in This Document . . . . . . . . . . . .   2
+     1.1.  Conventions Used in This Document . . . . . . . . . . . .   3
    2.  TJSON Grammar . . . . . . . . . . . . . . . . . . . . . . . .   3
      2.1.  String Grammar  . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  Root Symbol . . . . . . . . . . . . . . . . . . . . . . .   3
@@ -70,13 +70,15 @@ Table of Contents
      3.2.  Binary Data . . . . . . . . . . . . . . . . . . . . . . .   4
        3.2.1.  base16 ("b16:") . . . . . . . . . . . . . . . . . . .   4
        3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
-     3.3.  Integers ("i:") . . . . . . . . . . . . . . . . . . . . .   5
-     3.4.  Timestamps ("t:") . . . . . . . . . . . . . . . . . . . .   5
+     3.3.  Integers  . . . . . . . . . . . . . . . . . . . . . . . .   5
+       3.3.1.  Signed Integers ("i:")  . . . . . . . . . . . . . . .   5
+       3.3.2.  Unsigned Integers ("u:")  . . . . . . . . . . . . . .   5
+     3.4.  Timestamps ("t:") . . . . . . . . . . . . . . . . . . . .   6
    4.  Handling of JSON types  . . . . . . . . . . . . . . . . . . .   6
      4.1.  Objects . . . . . . . . . . . . . . . . . . . . . . . . .   6
      4.2.  Floating Points . . . . . . . . . . . . . . . . . . . . .   6
    5.  Normative References  . . . . . . . . . . . . . . . . . . . .   6
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   6
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   7
 
 1.  Introduction
 
@@ -100,11 +102,9 @@ Table of Contents
    also improve the ability to both canonicalize and authenticate JSON
    documents.
 
-1.1.  Conventions Used in This Document
 
-   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-   document are to be interpreted as described in [RFC2119].
+
+
 
 
 
@@ -113,6 +113,12 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 2]
 
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
+
+1.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
 
 2.  TJSON Grammar
 
@@ -155,12 +161,6 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
                        <root> ::= <object> | <array>
 
-   Documents which do not contain an object or array as the toplevel
-   element MUST be rejected by parsers.
-
-
-
-
 
 
 
@@ -169,6 +169,9 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 3]
 
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
+
+   Documents which do not contain an object or array as the toplevel
+   element MUST be rejected by parsers.
 
 3.  Extended Types
 
@@ -218,9 +221,6 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
 
 
-
-
-
 Arcieri & Laurie          Expires April 5, 2017                 [Page 4]
 
 Internet-Draft        TJSON Data Interchange Format         October 2016
@@ -244,20 +244,43 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    Only the base64url format is supported.  The non-URL safe form of
    base64 is not supported and MUST be rejected by parsers.
 
-3.3.  Integers ("i:")
+3.3.  Integers
 
-   TJSON provides a standard syntax for representing integers as tagged
-   strings, which allows representing more than the "[-(2**53)+1,
-   (2**53)-1]" range of integers defined as interoperable in [RFC7159].
+   TJSON provides standard syntax for representing integers as tagged
+   strings, which can express a larger range of values than the
+   "[-(2**53)+1, (2**53)-1]" range defined as interoperable in
+   [RFC7159].
 
-   An integer literal tagged string starts with the "i:" tag, followed
-   by a valid JSON integer literal, with an optional minus character.
+   Both signed and unsigned integers are supported and provide the same
+   ranges as 64-bit integers.
+
+3.3.1.  Signed Integers ("i:")
+
+   A signed integer literal is represented as string with an "i:" tag,
+   followed by a valid JSON integer literal, with an optional minus
+   ("-") character.
 
    Conforming TJSON parsers MUST be capable of supporting the full
-   integer range "[-(2**63), (2**63)-1]", i.e. the range of a signed
-   64-bit integer.
+   64-bit signed integer range "[-(2**63), (2**63)-1]" for this type.
 
    Integers outside this range MUST be rejected.
+
+3.3.2.  Unsigned Integers ("u:")
+
+   An unsigned integer literal is represented as a string with a "u:"
+   tag, followed by a valid JSON integer literal.  The minus ("-")
+   character is expressly disallowed and parsers MUST fail if it's
+   present.
+
+   Conforming TJSON parsers MUST be capable of supporting the full
+   64-bit unsigned integer range "[0, (2**64)-1]" for this type.
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
+
+Internet-Draft        TJSON Data Interchange Format         October 2016
+
 
 3.4.  Timestamps ("t:")
 
@@ -272,15 +295,6 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
    TJSON libraries SHOULD convert these timestamps to a native datetime
    type.
-
-
-
-
-
-Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
-
-Internet-Draft        TJSON Data Interchange Format         October 2016
-
 
 4.  Handling of JSON types
 
@@ -315,6 +329,15 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
               10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
               2003, <http://www.rfc-editor.org/info/rfc3629>.
 
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 6]
+
+Internet-Draft        TJSON Data Interchange Format         October 2016
+
+
    [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
               Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
               <http://www.rfc-editor.org/info/rfc4648>.
@@ -333,4 +356,37 @@ Authors' Addresses
 
 
 
-Arcieri & Laurie          Expires April 5, 2017                 [Page 6]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 7]

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -207,19 +207,35 @@ is not supported and MUST be rejected by parsers.
 </section>
 </section>
 
-<section anchor="integers-i" title="Integers (&quot;i:&quot;)">
-<t>TJSON provides a standard syntax for representing integers as tagged strings,
-which allows representing more than the <spanx style="verb">[-(2**53)+1, (2**53)-1]</spanx> range of
-integers defined as interoperable in <xref target="RFC7159"/>.
+<section anchor="integers" title="Integers">
+<t>TJSON provides standard syntax for representing integers as tagged strings,
+which can express a larger range of values than the <spanx style="verb">[-(2**53)+1, (2**53)-1]</spanx>
+range defined as interoperable in <xref target="RFC7159"/>.
 </t>
-<t>An integer literal tagged string starts with the &quot;i:&quot; tag, followed by a
-valid JSON integer literal, with an optional minus character.
+<t>Both signed and unsigned integers are supported and provide the same ranges
+as 64-bit integers.
 </t>
-<t>Conforming TJSON parsers MUST be capable of supporting the full integer range
-<spanx style="verb">[-(2**63), (2**63)-1]</spanx>, i.e. the range of a signed 64-bit integer.
+
+<section anchor="signed-integers-i" title="Signed Integers (&quot;i:&quot;)">
+<t>A signed integer literal is represented as string with an &quot;i:&quot; tag, followed
+by a valid JSON integer literal, with an optional minus (&quot;-&quot;) character.
+</t>
+<t>Conforming TJSON parsers MUST be capable of supporting the full 64-bit signed
+integer range <spanx style="verb">[-(2**63), (2**63)-1]</spanx> for this type.
 </t>
 <t>Integers outside this range MUST be rejected.
 </t>
+</section>
+
+<section anchor="unsigned-integers-u" title="Unsigned Integers (&quot;u:&quot;)">
+<t>An unsigned integer literal is represented as a string with a &quot;u:&quot; tag,
+followed by a valid JSON integer literal. The minus (&quot;-&quot;) character is
+expressly disallowed and parsers MUST fail if it's present.
+</t>
+<t>Conforming TJSON parsers MUST be capable of supporting the full 64-bit unsigned
+integer range <spanx style="verb">[0, (2**64)−1]</spanx> for this type.
+</t>
+</section>
 </section>
 
 <section anchor="timestamps-t" title="Timestamps (&quot;t:&quot;)">


### PR DESCRIPTION
Uses the "u:" syntax (previously used for UTF-8 Strings before that tag was changed to "s:") to represent unsigned 64-bit integers.
