### PR TITLE
Base32 Binary Encoding ("b32:")

### DIFF
--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -1,7 +1,7 @@
 #
 # [DRAFT] Annotated TJSON examples intended for testing TJSON parsers
 #
-# Revision: 14 (bump this when making changes to this file)
+# Revision: 15 (bump this when making changes to this file)
 #
 # Syntax used in this file:
 #
@@ -128,6 +128,41 @@ description = "Base16 data must be valid hexadecimal"
 result = "error"
 
 ["b16:This is not a valid hexadecimal string"]
+
+-----
+name = "Empty Base32 Binary Data"
+description = "Data in this format is represented by a bare b32: tag"
+result = "success"
+
+["b32:"]
+
+-----
+name = "Base32 Binary Data"
+description = "Base32 data begins with the 'b32:' prefix"
+result = "success"
+
+["b32:jbswy3dpfqqho33snrscc"]
+
+-----
+name = "Invalid Base32 Binary Data with bad case"
+description = "Base32 data MUST be lower case"
+result = "error"
+
+["b32:JBSWY3DPFQQHO33SNRSCC"]
+
+-----
+name = "Invalid Base32 Binary Data with padding"
+description = "Base64 data MUST NOT include padding"
+result = "error"
+
+["b32:jbswy3dpfqqho33snrscc==="]
+
+-----
+name = "Invalid Base32 Binary Data"
+description = "Base32 data must be valid"
+result = "error"
+
+["b32:This is not a valid base32 string"]
 
 -----
 name = "Empty Base64url Binary Data"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -137,7 +137,21 @@ The following is an example of a base16 string literal in TJSON:
 
     "b16:48656c6c6f2c20776f726c6421"
 
-This should decode to the equivalent of the ASCII string: "Hello, world!"
+This decodes to the equivalent of the ASCII string: "Hello, world!"
+
+### base32 ("b32:")
+
+A base32 literal starts with the "b16:" tag, followed by a valid base32 string.
+The base32 format is described in [@!RFC4648]. All base32 strings in TJSON
+MUST be lower case, and MUST NOT include any padding with the '=' character.
+TJSON parsers MUST reject any documents containing upper case base32 characters
+or padding.
+
+The following is an example of a base32 string literal in TJSON:
+
+    "b32:jbswy3dpfqqho33snrscc"
+
+This decodes to the equivalent of the ASCII string: "Hello, world!"
 
 ### base64url ("b64:")
 
@@ -150,7 +164,7 @@ The following is an example of a base64url string literal in TJSON:
 
     "b64:SGVsbG8sIHdvcmxkIQ"
 
-This should decode to the equivalent of the ASCII string: "Hello, world!"
+This decodes to the equivalent of the ASCII string: "Hello, world!"
 
 Only the base64url format is supported. The non-URL safe form of base64
 is not supported and MUST be rejected by parsers.

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -69,16 +69,17 @@ Table of Contents
      3.1.  UTF-8 Strings ("s:")  . . . . . . . . . . . . . . . . . .   4
      3.2.  Binary Data . . . . . . . . . . . . . . . . . . . . . . .   4
        3.2.1.  base16 ("b16:") . . . . . . . . . . . . . . . . . . .   4
-       3.2.2.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
+       3.2.2.  base32 ("b32:") . . . . . . . . . . . . . . . . . . .   5
+       3.2.3.  base64url ("b64:")  . . . . . . . . . . . . . . . . .   5
      3.3.  Integers  . . . . . . . . . . . . . . . . . . . . . . . .   5
        3.3.1.  Signed Integers ("i:")  . . . . . . . . . . . . . . .   5
-       3.3.2.  Unsigned Integers ("u:")  . . . . . . . . . . . . . .   5
+       3.3.2.  Unsigned Integers ("u:")  . . . . . . . . . . . . . .   6
      3.4.  Timestamps ("t:") . . . . . . . . . . . . . . . . . . . .   6
    4.  Handling of JSON types  . . . . . . . . . . . . . . . . . . .   6
      4.1.  Objects . . . . . . . . . . . . . . . . . . . . . . . . .   6
-     4.2.  Arrays  . . . . . . . . . . . . . . . . . . . . . . . . .   6
-     4.3.  Floating Points . . . . . . . . . . . . . . . . . . . . .   6
-   5.  Normative References  . . . . . . . . . . . . . . . . . . . .   6
+     4.2.  Arrays  . . . . . . . . . . . . . . . . . . . . . . . . .   7
+     4.3.  Floating Points . . . . . . . . . . . . . . . . . . . . .   7
+   5.  Normative References  . . . . . . . . . . . . . . . . . . . .   7
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   7
 
 1.  Introduction
@@ -102,7 +103,6 @@ Table of Contents
    interchange formats which disambiguate strings from binary data, and
    also improve the ability to both canonicalize and authenticate JSON
    documents.
-
 
 
 
@@ -215,8 +215,8 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
                      "b16:48656c6c6f2c20776f726c6421"
 
-   This should decode to the equivalent of the ASCII string: "Hello,
-   world!"
+   This decodes to the equivalent of the ASCII string: "Hello, world!"
+
 
 
 
@@ -226,7 +226,21 @@ Arcieri & Laurie          Expires April 5, 2017                 [Page 4]
 Internet-Draft        TJSON Data Interchange Format         October 2016
 
 
-3.2.2.  base64url ("b64:")
+3.2.2.  base32 ("b32:")
+
+   A base32 literal starts with the "b16:" tag, followed by a valid
+   base32 string.  The base32 format is described in [RFC4648].  All
+   base32 strings in TJSON MUST be lower case, and MUST NOT include any
+   padding with the '=' character.  TJSON parsers MUST reject any
+   documents containing upper case base32 characters or padding.
+
+   The following is an example of a base32 string literal in TJSON:
+
+                        "b32:jbswy3dpfqqho33snrscc"
+
+   This decodes to the equivalent of the ASCII string: "Hello, world!"
+
+3.2.3.  base64url ("b64:")
 
    A base64url literal starts with the "b64:" tag, followed by a valid
    base64url string.  The base64url format is described in [RFC4648].
@@ -238,8 +252,7 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
                          "b64:SGVsbG8sIHdvcmxkIQ"
 
-   This should decode to the equivalent of the ASCII string: "Hello,
-   world!"
+   This decodes to the equivalent of the ASCII string: "Hello, world!"
 
    Only the base64url format is supported.  The non-URL safe form of
    base64 is not supported and MUST be rejected by parsers.
@@ -260,6 +273,15 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    followed by a valid JSON integer literal, with an optional minus
    ("-") character.
 
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
+
+Internet-Draft        TJSON Data Interchange Format         October 2016
+
+
    Conforming TJSON parsers MUST be capable of supporting the full
    64-bit signed integer range "[-(2**63), (2**63)-1]" for this type.
 
@@ -274,13 +296,6 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
 
    Conforming TJSON parsers MUST be capable of supporting the full
    64-bit unsigned integer range "[0, (2**64)-1]" for this type.
-
-
-
-Arcieri & Laurie          Expires April 5, 2017                 [Page 5]
-
-Internet-Draft        TJSON Data Interchange Format         October 2016
-
 
 3.4.  Timestamps ("t:")
 
@@ -312,6 +327,17 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
    the same name for more than one member MUST be rejected by TJSON
    parsers.
 
+
+
+
+
+
+
+Arcieri & Laurie          Expires April 5, 2017                 [Page 6]
+
+Internet-Draft        TJSON Data Interchange Format         October 2016
+
+
 4.2.  Arrays
 
    Arrays have no additional handling considerations in TJSON.
@@ -328,15 +354,6 @@ Internet-Draft        TJSON Data Interchange Format         October 2016
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <http://www.rfc-editor.org/info/rfc2119>.
-
-
-
-
-
-Arcieri & Laurie          Expires April 5, 2017                 [Page 6]
-
-Internet-Draft        TJSON Data Interchange Format         October 2016
-
 
    [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
               Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
@@ -360,23 +377,6 @@ Authors' Addresses
 
 
    Ben Laurie
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -183,7 +183,24 @@ strings in TJSON MUST be lower case.
 <figure align="center"><artwork align="center">
 "b16:48656c6c6f2c20776f726c6421"
 </artwork></figure>
-<t>This should decode to the equivalent of the ASCII string: &quot;Hello, world!&quot;
+<t>This decodes to the equivalent of the ASCII string: &quot;Hello, world!&quot;
+</t>
+</section>
+
+<section anchor="base32-b32" title="base32 (&quot;b32:&quot;)">
+<t>A base32 literal starts with the &quot;b16:&quot; tag, followed by a valid base32 string.
+The base32 format is described in <xref target="RFC4648"/>. All base32 strings in TJSON
+MUST be lower case, and MUST NOT include any padding with the '=' character.
+TJSON parsers MUST reject any documents containing upper case base32 characters
+or padding.
+</t>
+<t>The following is an example of a base32 string literal in TJSON:
+</t>
+
+<figure align="center"><artwork align="center">
+"b32:jbswy3dpfqqho33snrscc"
+</artwork></figure>
+<t>This decodes to the equivalent of the ASCII string: &quot;Hello, world!&quot;
 </t>
 </section>
 
@@ -199,7 +216,7 @@ MUST reject any documents containing padded base64url strings.
 <figure align="center"><artwork align="center">
 "b64:SGVsbG8sIHdvcmxkIQ"
 </artwork></figure>
-<t>This should decode to the equivalent of the ASCII string: &quot;Hello, world!&quot;
+<t>This decodes to the equivalent of the ASCII string: &quot;Hello, world!&quot;
 </t>
 <t>Only the base64url format is supported. The non-URL safe form of base64
 is not supported and MUST be rejected by parsers.


### PR DESCRIPTION
Adds Base32 encoding, which strikes a nice balance between compactness and readability.
