### PR TITLE
Syntax for empty non-scalar types

### DIFF
--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -1,7 +1,7 @@
 #
 # [DRAFT] Annotated TJSON examples intended for testing TJSON parsers
 #
-# Revision: 19 (bump this when making changes to this file)
+# Revision: 20 (bump this when making changes to this file)
 #
 # Syntax used in this file:
 #
@@ -79,6 +79,20 @@ description = "Objects are the only allowed terminal non-scalar"
 result = "success"
 
 {"example:A<O>": [{"a:i": "1"}, {"b:i": "2"}]}
+
+-----
+name = "Empty array"
+description = "Empty arrays do not need a type parameter"
+result = "success"
+
+{"example:A<>": []}
+
+-----
+name = "Array with missing type parameter"
+description = "Type parameters are mandatory for non-empty arrays"
+result = "error"
+
+{"example:A<>": ["1", "2", "3"]}
 
 -----
 name = "Multidimensional array of integers"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -83,15 +83,15 @@ in TJSON are described by the following grammar:
 
     <member> ::= <tagged-string> <name-separator> <value>
 
-    <tagged-string> ::= '"' *<char> ':' <tag> '"'
+    <tagged-string> ::= '"' <char>* ':' <tag> '"'
 
     <tag> ::= <object-tag> | <type-expression> | <scalar-tag>
 
-    <type-expression> ::= <non-scalar-tag> '<' <tag> '>'
+    <type-expression> ::= <non-scalar-tag> '<' <tag>? '>'
 
-    <non-scalar-tag> ::= <alpha-upper> *<alphanumeric-lower>
+    <non-scalar-tag> ::= <alpha-upper> <alphanumeric-lower>*
 
-    <scalar-tag> ::= <alpha-lower> *<alphanumeric-lower>
+    <scalar-tag> ::= <alpha-lower> <alphanumeric-lower>*
 
     <object-tag> ::= 'O'
 
@@ -119,6 +119,11 @@ TJSON uses the case of tag names to identify scalar types vs non-scalars:
 
 * Scalars: lower-case tag names (e.g. "t")
 * Non-scalars: capitalized tag names (e.g. "A")
+
+Non-scalars are parameterized by an inner tag contained in '<' '>' characters,
+similar to the syntax used for generics in many programming languages.
+Omitting the inner tag (e.g. "A<>") is allowed in cases where the corresponding
+non-scalar value is empty.
 
 The "object-tag" nonterminal has a special place in the grammar: as the
 sole carrier of type information objects are the only nonterminal
@@ -281,6 +286,11 @@ The "A" tag, with an associated JSON array value, identifies a TJSON array.
 Non-scalars are parameterized by the types they contain, so fully identifying
 an array depends on its contents.
 
+Empty arrays do not have a corresponding inner type, in which case the inner
+type MAY be omitted from the type description. However, type parameters are
+mandatory unless the array is empty, and parsers MUST reject documents missing
+an inner type for non-empty arrays.
+
 The following is an example of a TJSON array containing integers:
 
     {"example:A<i>": ["1", "2", "3"]}
@@ -288,6 +298,10 @@ The following is an example of a TJSON array containing integers:
 The following is an example of a two dimensional array containing integers:
 
     {"example:A<A<i>>:" [["1", "2"], ["3", "4"], ["5", "6"]]}
+
+The following is an example of an empty array:
+
+    {"example:A<>": []}
 
 ## Objects ("O")
 

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -172,15 +172,15 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
    <member> ::= <tagged-string> <name-separator> <value>
 
-   <tagged-string> ::= '"' *<char> ':' <tag> '"'
+   <tagged-string> ::= '"' <char>* ':' <tag> '"'
 
    <tag> ::= <object-tag> | <type-expression> | <scalar-tag>
 
-   <type-expression> ::= <non-scalar-tag> '<' <tag> '>'
+   <type-expression> ::= <non-scalar-tag> '<' <tag>? '>'
 
-   <non-scalar-tag> ::= <alpha-upper> *<alphanumeric-lower>
+   <non-scalar-tag> ::= <alpha-upper> <alphanumeric-lower>*
 
-   <scalar-tag> ::= <alpha-lower> *<alphanumeric-lower>
+   <scalar-tag> ::= <alpha-lower> <alphanumeric-lower>*
 
    <object-tag> ::= 'O'
 
@@ -211,10 +211,10 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
    o  Non-scalars: capitalized tag names (e.g.  "A")
 
-   The "object-tag" nonterminal has a special place in the grammar: as
-   the sole carrier of type information objects are the only nonterminal
-   which does not carry type information.
-
+   Non-scalars are parameterized by an inner tag contained in '<' '>'
+   characters, similar to the syntax used for generics in many
+   programming languages.  Omitting the inner tag (e.g.  "A<>") is
+   allowed in cases where the corresponding non-scalar value is empty.
 
 
 
@@ -225,6 +225,10 @@ Arcieri & Laurie           Expires May 7, 2017                  [Page 4]
 
 Internet-Draft        TJSON Data Interchange Format        November 2016
 
+
+   The "object-tag" nonterminal has a special place in the grammar: as
+   the sole carrier of type information objects are the only nonterminal
+   which does not carry type information.
 
 2.2.  Root Symbol
 
@@ -269,10 +273,6 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    default unless another encoding is explicitly specified at
    serialization time.
 
-   The base16, base32, and base64url formats are mandatory to implement
-   for all TJSON parsers.
-
-
 
 
 
@@ -281,6 +281,9 @@ Arcieri & Laurie           Expires May 7, 2017                  [Page 5]
 
 Internet-Draft        TJSON Data Interchange Format        November 2016
 
+
+   The base16, base32, and base64url formats are mandatory to implement
+   for all TJSON parsers.
 
 3.2.1.  base16 ("b16")
 
@@ -327,9 +330,6 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    TJSON parsers MUST reject any documents containing padded base64url
    strings.
 
-   When serializing binary data as TJSON, encoders SHOULD use the "b"
-   tag to indicate binary data unless another format has been explicitly
-   specified.
 
 
 
@@ -337,6 +337,10 @@ Arcieri & Laurie           Expires May 7, 2017                  [Page 6]
 
 Internet-Draft        TJSON Data Interchange Format        November 2016
 
+
+   When serializing binary data as TJSON, encoders SHOULD use the "b"
+   tag to indicate binary data unless another format has been explicitly
+   specified.
 
    The following is an example of a base64url string literal in TJSON:
 
@@ -382,10 +386,6 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    character is expressly disallowed and parsers MUST reject documents
    containing it in an unsigned integer expression.
 
-   Conforming TJSON parsers MUST be capable of supporting the full
-   64-bit unsigned integer range "[0, (2**64)-1]" for this type.
-
-
 
 
 
@@ -393,6 +393,9 @@ Arcieri & Laurie           Expires May 7, 2017                  [Page 7]
 
 Internet-Draft        TJSON Data Interchange Format        November 2016
 
+
+   Conforming TJSON parsers MUST be capable of supporting the full
+   64-bit unsigned integer range "[0, (2**64)-1]" for this type.
 
 3.4.  Timestamps ("t")
 
@@ -418,6 +421,9 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    array.  Non-scalars are parameterized by the types they contain, so
    fully identifying an array depends on its contents.
 
+   Empty arrays do not have a corresponding inner type, in which case
+   the inner type may be omitted from the type description.
+
    The following is an example of a TJSON array containing integers:
 
                      {"example:A<i>": ["1", "2", "3"]}
@@ -427,11 +433,22 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
          {"example:A<A<i>>:" [["1", "2"], ["3", "4"], ["5", "6"]]}
 
+   The following is an example of an empty array:
+
+                            {"example:A<>": []}
+
 3.6.  Objects ("O")
 
    Type information MUST be present in all object member names (i.e. all
    member names must be tagged).  Parsers MUST reject objects with
    untagged members.
+
+
+
+Arcieri & Laurie           Expires May 7, 2017                  [Page 8]
+
+Internet-Draft        TJSON Data Interchange Format        November 2016
+
 
    When embedded within another non-scalar type such as an array,
    objects are identified by the tag "O".  Objects self-identify their
@@ -440,15 +457,6 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    The following is an example of an array of objects:
 
               {"example:A<O>": [{"a:i": "1"}, {"b:i": "2"}]}
-
-
-
-
-
-Arcieri & Laurie           Expires May 7, 2017                  [Page 8]
-
-Internet-Draft        TJSON Data Interchange Format        November 2016
-
 
    Object member names MUST be unique in TJSON.  Repeated use of the
    same name for more than one member MUST be rejected by TJSON parsers.
@@ -488,14 +496,6 @@ Authors' Addresses
 
 
    Ben Laurie
-
-
-
-
-
-
-
-
 
 
 

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -125,15 +125,15 @@ in TJSON are described by the following grammar:
 <figure align="center"><artwork align="center">
 &lt;member&gt; ::= &lt;tagged-string&gt; &lt;name-separator&gt; &lt;value&gt;
 
-&lt;tagged-string&gt; ::= '"' *&lt;char&gt; ':' &lt;tag&gt; '"'
+&lt;tagged-string&gt; ::= '"' &lt;char&gt;* ':' &lt;tag&gt; '"'
 
 &lt;tag&gt; ::= &lt;object-tag&gt; | &lt;type-expression&gt; | &lt;scalar-tag&gt;
 
-&lt;type-expression&gt; ::= &lt;non-scalar-tag&gt; '&lt;' &lt;tag&gt; '&gt;'
+&lt;type-expression&gt; ::= &lt;non-scalar-tag&gt; '&lt;' &lt;tag&gt;? '&gt;'
 
-&lt;non-scalar-tag&gt; ::= &lt;alpha-upper&gt; *&lt;alphanumeric-lower&gt;
+&lt;non-scalar-tag&gt; ::= &lt;alpha-upper&gt; &lt;alphanumeric-lower&gt;*
 
-&lt;scalar-tag&gt; ::= &lt;alpha-lower&gt; *&lt;alphanumeric-lower&gt;
+&lt;scalar-tag&gt; ::= &lt;alpha-lower&gt; &lt;alphanumeric-lower&gt;*
 
 &lt;object-tag&gt; ::= 'O'
 
@@ -164,6 +164,11 @@ The &quot;value&quot; pushdown remains the same.
 <t>Scalars: lower-case tag names (e.g. &quot;t&quot;)</t>
 <t>Non-scalars: capitalized tag names (e.g. &quot;A&quot;)</t>
 </list>
+</t>
+<t>Non-scalars are parameterized by an inner tag contained in '&lt;' '&gt;' characters,
+similar to the syntax used for generics in many programming languages.
+Omitting the inner tag (e.g. &quot;A&lt;&gt;&quot;) is allowed in cases where the corresponding
+non-scalar value is empty.
 </t>
 <t>The &quot;object-tag&quot; nonterminal has a special place in the grammar: as the
 sole carrier of type information objects are the only nonterminal
@@ -352,6 +357,9 @@ in section 2.1.
 Non-scalars are parameterized by the types they contain, so fully identifying
 an array depends on its contents.
 </t>
+<t>Empty arrays do not have a corresponding inner type, in which case the inner
+type may be omitted from the type description.
+</t>
 <t>The following is an example of a TJSON array containing integers:
 </t>
 
@@ -363,6 +371,12 @@ an array depends on its contents.
 
 <figure align="center"><artwork align="center">
 {"example:A&lt;A&lt;i&gt;&gt;:" [["1", "2"], ["3", "4"], ["5", "6"]]}
+</artwork></figure>
+<t>The following is an example of an empty array:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:A&lt;&gt;": []}
 </artwork></figure>
 </section>
 


### PR DESCRIPTION
Allow the inner type of non-scalars to be omitted in cases where the corresponding non-scalar value is empty (and thus the inner type information is irrelevant)