### PR TITLE
Sets (closes #22)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,8 @@ namespace :generate do
   task all: %w(xml txt)
 end
 
+task generate: %(generate:all)
+
 namespace :examples do
   task :verify do
     require "toml"

--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -1,7 +1,7 @@
 #
 # [DRAFT] Annotated TJSON examples intended for testing TJSON parsers
 #
-# Revision: 20 (bump this when making changes to this file)
+# Revision: 21 (bump this when making changes to this file)
 #
 # Syntax used in this file:
 #
@@ -23,13 +23,6 @@ description = "Objects are allowed as a toplevel value and can be empty"
 result = "success"
 
 {}
-
------
-name = "Invalid Toplevel Array"
-description = "Arrays are NOT allowed as a toplevel value"
-result = "error"
-
-[]
 
 -----
 name = "Object with UTF-8 String Key"
@@ -67,6 +60,13 @@ result = "error"
 {"example:i":"1","example:i":"1"}
 
 -----
+name = "Invalid Toplevel Array"
+description = "Arrays are NOT allowed as a toplevel value"
+result = "error"
+
+[]
+
+-----
 name = "Array of integers"
 description = "Arrays are parameterized by the types of their contents"
 result = "success"
@@ -82,7 +82,7 @@ result = "success"
 
 -----
 name = "Empty array"
-description = "Empty arrays do not need a type parameter"
+description = "Empty arrays are allowed to omit the type parameter"
 result = "success"
 
 {"example:A<>": []}
@@ -100,6 +100,62 @@ description = "Arrays can contain other arrays"
 result = "success"
 
 {"example:A<A<i>>": [["1", "2"], ["3", "4"], ["5", "6"]]}
+
+-----
+name = "Set of integers"
+description = "Sets are parameterized by the types of their contents"
+result = "success"
+
+{"example:S<i>": ["1", "2", "3"]}
+
+-----
+name = "Invalid set of integers with duplicate members"
+description = "The members of sets MUST be unique or the parser MUST reject the document"
+result = "error"
+
+{"example:S<i>": ["1", "1"]}
+
+-----
+name = "Set of objects"
+description = "Objects are the only allowed terminal non-scalar"
+result = "success"
+
+{"example:A<O>": [{"a:i": "1"}, {"b:i": "2"}]}
+
+-----
+name = "Invalid set of duplicate objects"
+description = "The members of sets MUST be unique or the parser MUST reject the document"
+result = "error"
+
+{"example:A<O>": [{"a:i": "1"}, {"a:i": "1"}]}
+
+-----
+name = "Empty set"
+description = "Empty sets are allowed to omit the type parameter"
+result = "success"
+
+{"example:S<>": []}
+
+-----
+name = "Set with missing type parameter"
+description = "Type parameters are mandatory for non-empty sets"
+result = "error"
+
+{"example:S<>": ["1", "2", "3"]}
+
+-----
+name = "Set containing arrays of integers"
+description = "Sets can contain arrays"
+result = "success"
+
+{"example:S<A<i>>": [["1", "2"], ["3", "4"], ["5", "6"]]}
+
+-----
+name = "Invalid set containing duplicate arrays"
+description = "Sets containing arrays must contain unique arrays"
+result = "error"
+
+{"example:S<A<i>>": [["1", "2"], ["1", "2"]]}
 
 -----
 name = "Base16 Binary Data"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -5,7 +5,7 @@
     category = "info"
     docName = "draft-tjson-spec"
     
-    date = 2016-11-03T20:00:00Z
+    date = 2017-04-15T20:00:00Z
     
     [[author]]
     initials = "T. "
@@ -300,7 +300,7 @@ The "A" tag, with an associated JSON array value, identifies a TJSON array.
 Non-scalars are parameterized by the types they contain, so fully identifying
 an array depends on its contents.
 
-Empty arrays do not have a corresponding inner type, in which case the inner
+Empty arrays do not require a corresponding inner type, in which case the inner
 type MAY be omitted from the type description. However, type parameters are
 mandatory unless the array is empty, and parsers MUST reject documents missing
 an inner type for non-empty arrays.
@@ -313,9 +313,41 @@ The following is an example of a two dimensional array containing integers:
 
     {"example:A<A<i>>:" [["1", "2"], ["3", "4"], ["5", "6"]]}
 
-The following is an example of an empty array:
+The following is an example of an empty array which omits its type parameter:
 
     {"example:A<>": []}
+
+An empty array containing an inner type signature is also valid:
+
+    {"example:A<i>": []}
+
+## Sets ("S")
+
+Sets are identified by the upper-case "S" tag and carry a type parameter like
+arrays. The associated value MUST use JSON array syntax.
+
+Unlike arrays, the members of sets MUST be unique. TJSON documents describing
+sets with duplicate members MUST be rejected by conforming parsers.
+
+Like empty arrays, the inner type definition for empty sets MAY be omitted from
+the type signature. A type paramater is mandatory for non-empty sets and MUST
+be included if the set has any members.
+
+The following is an example of a TJSON set of integers:
+
+    {"example:S<i>: ["1", "2", "3"]}
+
+Sets can contain arrays, and vice versa:
+
+    {"example:S<A<i>>": [["1", "2"], ["3", "4"]]}
+
+The following is an example of an empty set which omits its type parameter:
+
+    {"example:S<>": []}
+
+An empty set containing an inner type signature is also valid:
+
+    {"example:S<i>": []}
 
 ## Objects ("O")
 

--- a/generated/draft-tjson-spec.html
+++ b/generated/draft-tjson-spec.html
@@ -389,9 +389,10 @@
 <link href="#rfc.section.3.3.1" rel="Chapter" title="3.3.1 Signed Integers (&quot;i&quot;)"/>
 <link href="#rfc.section.3.3.2" rel="Chapter" title="3.3.2 Unsigned Integers (&quot;u&quot;)"/>
 <link href="#rfc.section.3.4" rel="Chapter" title="3.4 Timestamps (&quot;t&quot;)"/>
-<link href="#rfc.section.3.5" rel="Chapter" title="3.5 Arrays"/>
-<link href="#rfc.section.3.6" rel="Chapter" title="3.6 Objects"/>
-<link href="#rfc.section.3.7" rel="Chapter" title="3.7 Floating Points"/>
+<link href="#rfc.section.3.5" rel="Chapter" title="3.5 Arrays (&quot;A&quot;)"/>
+<link href="#rfc.section.3.6" rel="Chapter" title="3.6 Sets (&quot;S&quot;)"/>
+<link href="#rfc.section.3.7" rel="Chapter" title="3.7 Objects (&quot;O&quot;)"/>
+<link href="#rfc.section.3.8" rel="Chapter" title="3.8 Floating Points"/>
 <link href="#rfc.references" rel="Chapter" title="4 Normative References"/>
 <link href="#rfc.authors" rel="Chapter"/>
 
@@ -473,9 +474,10 @@
 <ul><li>3.3.1.   <a href="#rfc.section.3.3.1">Signed Integers ("i")</a></li>
 <li>3.3.2.   <a href="#rfc.section.3.3.2">Unsigned Integers ("u")</a></li>
 </ul><li>3.4.   <a href="#rfc.section.3.4">Timestamps ("t")</a></li>
-<li>3.5.   <a href="#rfc.section.3.5">Arrays</a></li>
-<li>3.6.   <a href="#rfc.section.3.6">Objects</a></li>
-<li>3.7.   <a href="#rfc.section.3.7">Floating Points</a></li>
+<li>3.5.   <a href="#rfc.section.3.5">Arrays ("A")</a></li>
+<li>3.6.   <a href="#rfc.section.3.6">Sets ("S")</a></li>
+<li>3.7.   <a href="#rfc.section.3.7">Objects ("O")</a></li>
+<li>3.8.   <a href="#rfc.section.3.8">Floating Points</a></li>
 </ul><li>4.   <a href="#rfc.references">Normative References</a></li>
 <li><a href="#rfc.authors">Authors' Addresses</a></li>
 
@@ -518,15 +520,15 @@
 <pre>
 &lt;member&gt; ::= &lt;tagged-string&gt; &lt;name-separator&gt; &lt;value&gt;
 
-&lt;tagged-string&gt; ::= '"' *&lt;char&gt; ':' &lt;tag&gt; '"'
+&lt;tagged-string&gt; ::= '"' &lt;char&gt;* ':' &lt;tag&gt; '"'
 
-&lt;tag&gt; ::= &lt;type-expression&gt; | &lt;scalar-tag&gt; | &lt;object-tag&gt;
+&lt;tag&gt; ::= &lt;object-tag&gt; | &lt;type-expression&gt; | &lt;scalar-tag&gt;
 
-&lt;type-expression&gt; ::= &lt;non-scalar-tag&gt; '&lt;' &lt;tag&gt; '&gt;'
+&lt;type-expression&gt; ::= &lt;non-scalar-tag&gt; '&lt;' &lt;tag&gt;? '&gt;'
 
-&lt;non-scalar-tag&gt; ::= &lt;alpha-upper&gt; *&lt;alphanumeric-lower&gt;
+&lt;non-scalar-tag&gt; ::= &lt;alpha-upper&gt; &lt;alphanumeric-lower&gt;*
 
-&lt;scalar-tag&gt; ::= &lt;alpha-lower&gt; *&lt;alphanumeric-lower&gt;
+&lt;scalar-tag&gt; ::= &lt;alpha-lower&gt; &lt;alphanumeric-lower&gt;*
 
 &lt;object-tag&gt; ::= 'O'
 
@@ -555,6 +557,8 @@
 </ul>
 
 <p> </p>
+<p id="rfc.section.2.1.p.6">Non-scalars are parameterized by an inner tag contained in '&lt;' '&gt;' characters, similar to the syntax used for generics in many programming languages.  Omitting the inner tag (e.g. "A&lt;&gt;") is allowed in cases where the corresponding non-scalar value is empty.  </p>
+<p id="rfc.section.2.1.p.7">The "object-tag" nonterminal has a special place in the grammar: as the sole carrier of type information objects are the only nonterminal which does not carry type information.  </p>
 <h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> <a href="#root-symbol" id="root-symbol">Root Symbol</a></h1>
 <p id="rfc.section.2.2.p.1">The root grammatical symbol of all TJSON documents is constrained to the "object" nonterminal as described in <a href="#RFC7159">[RFC7159]</a>: </p>
 <pre>
@@ -622,27 +626,56 @@
 {"example:t":"2016-10-02T07:31:51Z"}
 </pre>
 <p id="rfc.section.3.4.p.3">TJSON libraries SHOULD convert these timestamps to a native date/time type.  </p>
-<h1 id="rfc.section.3.5"><a href="#rfc.section.3.5">3.5.</a> <a href="#arrays" id="arrays">Arrays</a></h1>
+<h1 id="rfc.section.3.5"><a href="#rfc.section.3.5">3.5.</a> <a href="#arrays-a" id="arrays-a">Arrays ("A")</a></h1>
 <p id="rfc.section.3.5.p.1">Arrays are a non-scalar and therefore use an upper case tag name as described in section 2.1.  </p>
 <p id="rfc.section.3.5.p.2">The "A" tag, with an associated JSON array value, identifies a TJSON array.  Non-scalars are parameterized by the types they contain, so fully identifying an array depends on its contents.  </p>
-<p id="rfc.section.3.5.p.3">The following is an example of a TJSON array containing integers: </p>
+<p id="rfc.section.3.5.p.3">Empty arrays do not require a corresponding inner type, in which case the inner type MAY be omitted from the type description. However, type parameters are mandatory unless the array is empty, and parsers MUST reject documents missing an inner type for non-empty arrays.  </p>
+<p id="rfc.section.3.5.p.4">The following is an example of a TJSON array containing integers: </p>
 <pre>
 {"example:A&lt;i&gt;": ["1", "2", "3"]}
 </pre>
-<p id="rfc.section.3.5.p.4">The following is an example of a two dimensional array containing integers: </p>
+<p id="rfc.section.3.5.p.5">The following is an example of a two dimensional array containing integers: </p>
 <pre>
 {"example:A&lt;A&lt;i&gt;&gt;:" [["1", "2"], ["3", "4"], ["5", "6"]]}
 </pre>
-<h1 id="rfc.section.3.6"><a href="#rfc.section.3.6">3.6.</a> <a href="#objects" id="objects">Objects</a></h1>
-<p id="rfc.section.3.6.p.1">Type information MUST be present in all object member names (i.e. all member names must be tagged). Parsers MUST reject objects with untagged members.  </p>
-<p id="rfc.section.3.6.p.2">When embedded within another non-scalar type such as an array, objects are identified by the tag "O". Objects self-identify their types, so do not need to be parameterized in type expressions.  </p>
-<p id="rfc.section.3.6.p.3">The following is an example of an array of objects: </p>
+<p id="rfc.section.3.5.p.6">The following is an example of an empty array which omits its type parameter: </p>
+<pre>
+{"example:A&lt;&gt;": []}
+</pre>
+<p id="rfc.section.3.5.p.7">An empty array containing an inner type signature is also valid: </p>
+<pre>
+{"example:A&lt;i&gt;": []}
+</pre>
+<h1 id="rfc.section.3.6"><a href="#rfc.section.3.6">3.6.</a> <a href="#sets-s" id="sets-s">Sets ("S")</a></h1>
+<p id="rfc.section.3.6.p.1">Sets are identified by the upper-case "S" tag and carry a type parameter like arrays. The associated value MUST use JSON array syntax.  </p>
+<p id="rfc.section.3.6.p.2">Unlike arrays, the members of sets MUST be unique. TJSON documents describing sets with duplicate members MUST be rejected by conforming parsers.  </p>
+<p id="rfc.section.3.6.p.3">Like empty arrays, the inner type definition for empty sets MAY be omitted from the type signature. A type paramater is mandatory for non-empty sets and MUST be included if the set has any members.  </p>
+<p id="rfc.section.3.6.p.4">The following is an example of a TJSON set of integers: </p>
+<pre>
+{"example:S&lt;i&gt;: ["1", "2", "3"]}
+</pre>
+<p id="rfc.section.3.6.p.5">Sets can contain arrays, and vice versa: </p>
+<pre>
+{"example:S&lt;A&lt;i&gt;&gt;": [["1", "2"], ["3", "4"]]}
+</pre>
+<p id="rfc.section.3.6.p.6">The following is an example of an empty set which omits its type parameter: </p>
+<pre>
+{"example:S&lt;&gt;": []}
+</pre>
+<p id="rfc.section.3.6.p.7">An empty set containing an inner type signature is also valid: </p>
+<pre>
+{"example:S&lt;i&gt;": []}
+</pre>
+<h1 id="rfc.section.3.7"><a href="#rfc.section.3.7">3.7.</a> <a href="#objects-o" id="objects-o">Objects ("O")</a></h1>
+<p id="rfc.section.3.7.p.1">Type information MUST be present in all object member names (i.e. all member names must be tagged). Parsers MUST reject objects with untagged members.  </p>
+<p id="rfc.section.3.7.p.2">When embedded within another non-scalar type such as an array, objects are identified by the tag "O". Objects self-identify their types, so do not need to be parameterized in type expressions.  </p>
+<p id="rfc.section.3.7.p.3">The following is an example of an array of objects: </p>
 <pre>
 {"example:A&lt;O&gt;": [{"a:i": "1"}, {"b:i": "2"}]}
 </pre>
-<p id="rfc.section.3.6.p.4">Object member names MUST be unique in TJSON. Repeated use of the same name for more than one member MUST be rejected by TJSON parsers.  </p>
-<h1 id="rfc.section.3.7"><a href="#rfc.section.3.7">3.7.</a> <a href="#floating-points" id="floating-points">Floating Points</a></h1>
-<p id="rfc.section.3.7.p.1">All numeric literals which are not represented as tagged strings MUST be treated as floating points under TJSON. This is already the default behavior of many JSON libraries.  </p>
+<p id="rfc.section.3.7.p.4">Object member names MUST be unique in TJSON. Repeated use of the same name for more than one member MUST be rejected by TJSON parsers.  </p>
+<h1 id="rfc.section.3.8"><a href="#rfc.section.3.8">3.8.</a> <a href="#floating-points" id="floating-points">Floating Points</a></h1>
+<p id="rfc.section.3.8.p.1">All numeric literals which are not represented as tagged strings MUST be treated as floating points under TJSON. This is already the default behavior of many JSON libraries.  </p>
 <h1 id="rfc.references"><a href="#rfc.references">4.</a> Normative References</h1>
 <table>
   <tbody>

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -5,7 +5,7 @@
 Network Working Group                                         T. Arcieri
 Internet-Draft
 Intended status: Informational                                 B. Laurie
-Expires: May 7, 2017                                    November 3, 2016
+Expires: October 17, 2017                                 April 15, 2017
 
 
    Tagged JavaScript Object Notation (TJSON) Data Interchange Format
@@ -34,11 +34,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 7, 2017.
+   This Internet-Draft will expire on October 17, 2017.
 
 Copyright Notice
 
-   Copyright (c) 2016 IETF Trust and the persons identified as the
+   Copyright (c) 2017 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Arcieri & Laurie           Expires May 7, 2017                  [Page 1]
+Arcieri & Laurie        Expires October 17, 2017                [Page 1]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
 Table of Contents
@@ -74,12 +74,14 @@ Table of Contents
      3.3.  Integers  . . . . . . . . . . . . . . . . . . . . . . . .   7
        3.3.1.  Signed Integers ("i") . . . . . . . . . . . . . . . .   7
        3.3.2.  Unsigned Integers ("u") . . . . . . . . . . . . . . .   7
-     3.4.  Timestamps ("t")  . . . . . . . . . . . . . . . . . . . .   8
-     3.5.  Arrays ("A")  . . . . . . . . . . . . . . . . . . . . . .   8
-     3.6.  Objects ("O") . . . . . . . . . . . . . . . . . . . . . .   8
-     3.7.  Floating Points . . . . . . . . . . . . . . . . . . . . .   9
-   4.  Normative References  . . . . . . . . . . . . . . . . . . . .   9
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   9
+     3.4.  Floating Points ("f") . . . . . . . . . . . . . . . . . .   8
+     3.5.  Timestamps ("t")  . . . . . . . . . . . . . . . . . . . .   8
+     3.6.  Boolean Values ("v")  . . . . . . . . . . . . . . . . . .   8
+     3.7.  Arrays ("A")  . . . . . . . . . . . . . . . . . . . . . .   8
+     3.8.  Sets ("S")  . . . . . . . . . . . . . . . . . . . . . . .   9
+     3.9.  Objects ("O") . . . . . . . . . . . . . . . . . . . . . .  10
+   4.  Normative References  . . . . . . . . . . . . . . . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  10
 
 1.  Introduction
 
@@ -104,15 +106,15 @@ Table of Contents
 
    It supports two non-scalar types:
 
-   o  Objects
 
 
 
-
-Arcieri & Laurie           Expires May 7, 2017                  [Page 2]
+Arcieri & Laurie        Expires October 17, 2017                [Page 2]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
+
+   o  Objects
 
    o  Arrays
 
@@ -163,11 +165,9 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
 
 
-
-
-Arcieri & Laurie           Expires May 7, 2017                  [Page 3]
+Arcieri & Laurie        Expires October 17, 2017                [Page 3]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
    <member> ::= <tagged-string> <name-separator> <value>
@@ -221,9 +221,9 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
 
 
-Arcieri & Laurie           Expires May 7, 2017                  [Page 4]
+Arcieri & Laurie        Expires October 17, 2017                [Page 4]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
    The "object-tag" nonterminal has a special place in the grammar: as
@@ -277,9 +277,9 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
 
 
-Arcieri & Laurie           Expires May 7, 2017                  [Page 5]
+Arcieri & Laurie        Expires October 17, 2017                [Page 5]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
    The base16, base32, and base64url formats are mandatory to implement
@@ -333,9 +333,9 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
 
 
-Arcieri & Laurie           Expires May 7, 2017                  [Page 6]
+Arcieri & Laurie        Expires October 17, 2017                [Page 6]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
    When serializing binary data as TJSON, encoders SHOULD use the "b"
@@ -389,15 +389,24 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
 
 
-Arcieri & Laurie           Expires May 7, 2017                  [Page 7]
+Arcieri & Laurie        Expires October 17, 2017                [Page 7]
 
-Internet-Draft        TJSON Data Interchange Format        November 2016
+Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
    Conforming TJSON parsers MUST be capable of supporting the full
    64-bit unsigned integer range "[0, (2**64)-1]" for this type.
 
-3.4.  Timestamps ("t")
+3.4.  Floating Points ("f")
+
+   Floating points are identified by the "f" tag, with an associated
+   JSON float literal value.  Unlike integers, floating point values
+   should NOT be quoted strings, but should use the native JSON syntax.
+
+   Conforming TJSON parsers MUST ensure the resulting type of a parsed
+   floating point is actually a floating point, and not an integer.
+
+3.5.  Timestamps ("t")
 
    TJSON natively supports a timestamp type whose syntax is a subset of
    that provided by [RFC3339].  Specifically, TJSON timestamps MUST use
@@ -412,7 +421,13 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    TJSON libraries SHOULD convert these timestamps to a native date/time
    type.
 
-3.5.  Arrays ("A")
+3.6.  Boolean Values ("v")
+
+   Boolean values are identified by the "v" tag.  Only the "true" and
+   "false" values are allowed: "null" MUST be rejected with a parse
+   error.
+
+3.7.  Arrays ("A")
 
    Arrays are a non-scalar and therefore use an upper case tag name as
    described in section 2.1.
@@ -421,10 +436,19 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
    array.  Non-scalars are parameterized by the types they contain, so
    fully identifying an array depends on its contents.
 
-   Empty arrays do not have a corresponding inner type, in which case
-   the inner type may be omitted from the type description.
+   Empty arrays do not require a corresponding inner type, in which case
+   the inner type MAY be omitted from the type description.  However,
+   type parameters are mandatory unless the array is empty, and parsers
+   MUST reject documents missing an inner type for non-empty arrays.
 
    The following is an example of a TJSON array containing integers:
+
+
+
+Arcieri & Laurie        Expires October 17, 2017                [Page 8]
+
+Internet-Draft        TJSON Data Interchange Format           April 2017
+
 
                      {"example:A<i>": ["1", "2", "3"]}
 
@@ -433,22 +457,60 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
          {"example:A<A<i>>:" [["1", "2"], ["3", "4"], ["5", "6"]]}
 
-   The following is an example of an empty array:
+   The following is an example of an empty array which omits its type
+   parameter:
 
                             {"example:A<>": []}
 
-3.6.  Objects ("O")
+   An empty array containing an inner type signature is also valid:
+
+                           {"example:A<i>": []}
+
+3.8.  Sets ("S")
+
+   Sets are identified by the upper-case "S" tag and carry a type
+   parameter like arrays.  The associated value MUST use JSON array
+   syntax.
+
+   Unlike arrays, the members of sets MUST be unique.  TJSON documents
+   describing sets with duplicate members MUST be rejected by conforming
+   parsers.
+
+   Like empty arrays, the inner type definition for empty sets MAY be
+   omitted from the type signature.  A type paramater is mandatory for
+   non-empty sets and MUST be included if the set has any members.
+
+   The following is an example of a TJSON set of integers:
+
+                     {"example:S<i>: ["1", "2", "3"]}
+
+   Sets can contain arrays, and vice versa:
+
+               {"example:S<A<i>>": [["1", "2"], ["3", "4"]]}
+
+   The following is an example of an empty set which omits its type
+   parameter:
+
+                            {"example:S<>": []}
+
+   An empty set containing an inner type signature is also valid:
+
+                           {"example:S<i>": []}
+
+
+
+
+
+Arcieri & Laurie        Expires October 17, 2017                [Page 9]
+
+Internet-Draft        TJSON Data Interchange Format           April 2017
+
+
+3.9.  Objects ("O")
 
    Type information MUST be present in all object member names (i.e. all
    member names must be tagged).  Parsers MUST reject objects with
    untagged members.
-
-
-
-Arcieri & Laurie           Expires May 7, 2017                  [Page 8]
-
-Internet-Draft        TJSON Data Interchange Format        November 2016
-
 
    When embedded within another non-scalar type such as an array,
    objects are identified by the tag "O".  Objects self-identify their
@@ -460,12 +522,6 @@ Internet-Draft        TJSON Data Interchange Format        November 2016
 
    Object member names MUST be unique in TJSON.  Repeated use of the
    same name for more than one member MUST be rejected by TJSON parsers.
-
-3.7.  Floating Points
-
-   All numeric literals which are not represented as tagged strings MUST
-   be treated as floating points under TJSON.  This is already the
-   default behavior of many JSON libraries.
 
 4.  Normative References
 
@@ -501,4 +557,4 @@ Authors' Addresses
 
 
 
-Arcieri & Laurie           Expires May 7, 2017                  [Page 9]
+Arcieri & Laurie        Expires October 17, 2017               [Page 10]

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -42,7 +42,7 @@
 <uri></uri>
 </address>
 </author>
-<date year="2016" month="November" day="3"/>
+<date year="2017" month="April" day="15"/>
 
 <area>Internet</area>
 <workgroup></workgroup>
@@ -332,6 +332,16 @@ integer range <spanx style="verb">[0, (2**64)−1]</spanx> for this type.
 </section>
 </section>
 
+<section anchor="floating-points-f" title="Floating Points (&quot;f&quot;)">
+<t>Floating points are identified by the &quot;f&quot; tag, with an associated JSON float
+literal value. Unlike integers, floating point values should NOT be quoted
+strings, but should use the native JSON syntax.
+</t>
+<t>Conforming TJSON parsers MUST ensure the resulting type of a parsed floating
+point is actually a floating point, and not an integer.
+</t>
+</section>
+
 <section anchor="timestamps-t" title="Timestamps (&quot;t&quot;)">
 <t>TJSON natively supports a timestamp type whose syntax is a subset of that
 provided by <xref target="RFC3339"/>. Specifically, TJSON timestamps MUST use only the
@@ -349,6 +359,12 @@ allow them.
 </t>
 </section>
 
+<section anchor="boolean-values-v" title="Boolean Values (&quot;v&quot;)">
+<t>Boolean values are identified by the &quot;v&quot; tag. Only the <spanx style="verb">true</spanx> and <spanx style="verb">false</spanx>
+values are allowed: <spanx style="verb">null</spanx> MUST be rejected with a parse error.
+</t>
+</section>
+
 <section anchor="arrays-a" title="Arrays (&quot;A&quot;)">
 <t>Arrays are a non-scalar and therefore use an upper case tag name as described
 in section 2.1.
@@ -357,8 +373,10 @@ in section 2.1.
 Non-scalars are parameterized by the types they contain, so fully identifying
 an array depends on its contents.
 </t>
-<t>Empty arrays do not have a corresponding inner type, in which case the inner
-type may be omitted from the type description.
+<t>Empty arrays do not require a corresponding inner type, in which case the inner
+type MAY be omitted from the type description. However, type parameters are
+mandatory unless the array is empty, and parsers MUST reject documents missing
+an inner type for non-empty arrays.
 </t>
 <t>The following is an example of a TJSON array containing integers:
 </t>
@@ -372,11 +390,54 @@ type may be omitted from the type description.
 <figure align="center"><artwork align="center">
 {"example:A&lt;A&lt;i&gt;&gt;:" [["1", "2"], ["3", "4"], ["5", "6"]]}
 </artwork></figure>
-<t>The following is an example of an empty array:
+<t>The following is an example of an empty array which omits its type parameter:
 </t>
 
 <figure align="center"><artwork align="center">
 {"example:A&lt;&gt;": []}
+</artwork></figure>
+<t>An empty array containing an inner type signature is also valid:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:A&lt;i&gt;": []}
+</artwork></figure>
+</section>
+
+<section anchor="sets-s" title="Sets (&quot;S&quot;)">
+<t>Sets are identified by the upper-case &quot;S&quot; tag and carry a type parameter like
+arrays. The associated value MUST use JSON array syntax.
+</t>
+<t>Unlike arrays, the members of sets MUST be unique. TJSON documents describing
+sets with duplicate members MUST be rejected by conforming parsers.
+</t>
+<t>Like empty arrays, the inner type definition for empty sets MAY be omitted from
+the type signature. A type paramater is mandatory for non-empty sets and MUST
+be included if the set has any members.
+</t>
+<t>The following is an example of a TJSON set of integers:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:S&lt;i&gt;: ["1", "2", "3"]}
+</artwork></figure>
+<t>Sets can contain arrays, and vice versa:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:S&lt;A&lt;i&gt;&gt;": [["1", "2"], ["3", "4"]]}
+</artwork></figure>
+<t>The following is an example of an empty set which omits its type parameter:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:S&lt;&gt;": []}
+</artwork></figure>
+<t>An empty set containing an inner type signature is also valid:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:S&lt;i&gt;": []}
 </artwork></figure>
 </section>
 
@@ -396,13 +457,6 @@ not need to be parameterized in type expressions.
 </artwork></figure>
 <t>Object member names MUST be unique in TJSON. Repeated use of the same
 name for more than one member MUST be rejected by TJSON parsers.
-</t>
-</section>
-
-<section anchor="floating-points" title="Floating Points">
-<t>All numeric literals which are not represented as tagged strings MUST be
-treated as floating points under TJSON. This is already the default behavior
-of many JSON libraries.
 </t>
 </section>
 </section>


### PR DESCRIPTION
Sets are non-scalars containing only unique elements.

This adds a set type tagged as `S` and represented as a JSON array.

Sets are required to contain only unique members. Parsers MUST reject sets containing non-unique members.

cc @benlaurie 