### PR TITLE
Booleans (closes #44)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     citrus (3.0.2)
-    rake (11.3.0)
-    toml-rb (0.3.14)
+    rake (12.0.0)
+    toml-rb (0.3.15)
       citrus (~> 3.0, > 3.0)
 
 PLATFORMS
@@ -14,4 +14,4 @@ DEPENDENCIES
   toml-rb
 
 BUNDLED WITH
-   1.13.2
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ IETF-style specification for TJSON authored using [mmark].
       "float-example:f": 0.42,
       "int-example:i": "42",
       "timestamp-example:t": "2016-11-06T22:27:34Z"
+      "value-example:v": true
     }
   ]
 }

--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -270,3 +270,73 @@ result = "error"
 {"invalid:t":"This is not a valid timestamp"}
 
 -----
+name = "True Value"
+description = "True is allowed as a TJSON value"
+result = "success"
+
+{"example:v": true}
+
+-----
+name = "False Value"
+description = "False is allowed as a TJSON value"
+result = "success"
+
+{"example:v": false}
+
+-----
+name = "Null Value"
+description = "Null is disallowed as a TJSON value"
+result = "error"
+
+{"example:v": null}
+
+-----
+name = "Null Object"
+description = "Null is disallowed as a TJSON object"
+result = "error"
+
+{"example:O": null}
+
+-----
+name = "Null Array"
+description = "Null is disallowed as a TJSON array"
+result = "error"
+
+{"example:A<O>": [null]}
+
+-----
+name = "Null String"
+description = "Null is disallowed as a TJSON string"
+result = "error"
+
+{"example:s": null}
+
+-----
+name = "Null Binary"
+description = "Null is disallowed as a TJSON binary"
+result = "error"
+
+{"example:b": null}
+
+-----
+name = "Null Integer"
+description = "Null is disallowed as a TJSON integer"
+result = "error"
+
+{"example:i": null}
+
+-----
+name = "Null Unsigned"
+description = "Null is disallowed as a TJSON unsigned integer"
+result = "error"
+
+{"example:u": null}
+
+-----
+name = "Null Timestamp"
+description = "Null is disallowed as a TJSON timestamp"
+result = "error"
+
+{"example:t": null}
+
+-----

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -277,6 +277,11 @@ The following is an example of a TJSON timestamp:
 
 TJSON libraries SHOULD convert these timestamps to a native date/time type.
 
+## Boolean Values ("v")
+
+Boolean values are identified by the "v" tag. Only the `true` and `false`
+values are allowed: `null` MUST be rejected with a parse error.
+
 ## Arrays ("A")
 
 Arrays are a non-scalar and therefore use an upper case tag name as described


### PR DESCRIPTION
Booleans are tagged `v` for value, the name by which they're described in JSON.

Null is expressly disallowed. Tests have been added to confirm all types are non-nullable.