### PR TITLE
Implement #48: Use "b" for Boolean (reassigning Binary to "d")

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ IETF-style specification for TJSON authored using [mmark].
   "array-example:A<O>": [
     {
       "string-example:s": "foobar",
-      "binary-example:b64": "QklOQVJZ",
+      "binary-data-example:d": "QklOQVJZ",
       "float-example:f": 0.42,
       "int-example:i": "42",
       "timestamp-example:t": "2016-11-06T22:27:34Z",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ IETF-style specification for TJSON authored using [mmark].
       "float-example:f": 0.42,
       "int-example:i": "42",
       "timestamp-example:t": "2016-11-06T22:27:34Z",
-      "value-example:v": true
+      "boolean-example:b": true
     }
   ],
   "set-example:S<i>": [1, 2, 3]

--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -1,7 +1,7 @@
 #
 # [DRAFT] Annotated TJSON examples intended for testing TJSON parsers
 #
-# Revision: 22 (bump this when making changes to this file)
+# Revision: 23 (bump this when making changes to this file)
 #
 # Syntax used in this file:
 #
@@ -169,77 +169,77 @@ name = "Base16 Binary Data"
 description = "Base16 data begins with the 'b16:' prefix"
 result = "success"
 
-{"example:b16":"48656c6c6f2c20776f726c6421"}
+{"example:d16":"48656c6c6f2c20776f726c6421"}
 
 -----
 name = "Invalid Base16 Binary Data with bad case"
 description = "Base16 data MUST be lower case"
 result = "error"
 
-{"example:b16":"48656C6C6F2C20776F726C6421"}
+{"example:d16":"48656C6C6F2C20776F726C6421"}
 
 -----
 name = "Invalid Base16 Binary Data"
 description = "Base16 data must be valid hexadecimal"
 result = "error"
 
-{"example:b16":"This is not a valid hexadecimal string"}
+{"example:d16":"This is not a valid hexadecimal string"}
 
 -----
 name = "Base32 Binary Data"
 description = "Base32 data begins with the 'b32:' prefix"
 result = "success"
 
-{"example:b32":"jbswy3dpfqqho33snrscc"}
+{"example:d32":"jbswy3dpfqqho33snrscc"}
 
 -----
 name = "Invalid Base32 Binary Data with bad case"
 description = "Base32 data MUST be lower case"
 result = "error"
 
-{"example:b32":"JBSWY3DPFQQHO33SNRSCC"}
+{"example:d32":"JBSWY3DPFQQHO33SNRSCC"}
 
 -----
 name = "Invalid Base32 Binary Data with padding"
 description = "Base64 data MUST NOT include padding"
 result = "error"
 
-{"example:b32":"jbswy3dpfqqho33snrscc==="}
+{"example:d32":"jbswy3dpfqqho33snrscc==="}
 
 -----
 name = "Invalid Base32 Binary Data"
 description = "Base32 data must be valid"
 result = "error"
 
-{"example:b32":"This is not a valid base32 string"}
+{"example:d32":"This is not a valid base32 string"}
 
 -----
 name = "Base64url Binary Data"
 description = "Base64 data begins with the 'b64:' prefix"
 result = "success"
 
-{"example:b64":"SGVsbG8sIHdvcmxkIQ"}
+{"example:d64":"SGVsbG8sIHdvcmxkIQ"}
 
 -----
 name = "Invalid Base64url Binary Data with padding"
 description = "Base64 data MUST NOT include padding"
 result = "error"
 
-{"example:b64":"SGVsbG8sIHdvcmxkIQ=="}
+{"example:d64":"SGVsbG8sIHdvcmxkIQ=="}
 
 -----
 name = "Invalid Base64url Binary Data with non-URL safe characters"
 description = "Traditional Base64 is expressly disallowed"
 result = "error"
 
-{"example:b64":"+/+/"}
+{"example:d64":"+/+/"}
 
 -----
 name = "Invalid Base64url Binary Data"
 description = "Garbage data MUST be rejected"
 result = "error"
 
-{"example:b64":"This is not a valid base64url string"}
+{"example:d64":"This is not a valid base64url string"}
 
 -----
 name = "Signed Integer"
@@ -389,11 +389,11 @@ result = "error"
 {"example:s": null}
 
 -----
-name = "Null Binary"
+name = "Null Binary Data"
 description = "Null is disallowed as a TJSON binary"
 result = "error"
 
-{"example:b": null}
+{"example:d": null}
 
 -----
 name = "Null Integer"

--- a/draft-tjson-examples.txt
+++ b/draft-tjson-examples.txt
@@ -1,7 +1,7 @@
 #
 # [DRAFT] Annotated TJSON examples intended for testing TJSON parsers
 #
-# Revision: 23 (bump this when making changes to this file)
+# Revision: 24 (bump this when making changes to this file)
 #
 # Syntax used in this file:
 #
@@ -347,25 +347,25 @@ result = "error"
 {"invalid:t":"This is not a valid timestamp"}
 
 -----
-name = "True Value"
+name = "True Boolean Value"
 description = "True is allowed as a TJSON value"
 result = "success"
 
-{"example:v": true}
+{"example:b": true}
 
 -----
-name = "False Value"
+name = "False Boolean Value"
 description = "False is allowed as a TJSON value"
 result = "success"
 
-{"example:v": false}
+{"example:b": false}
 
 -----
-name = "Null Value"
+name = "Null Boolean Value"
 description = "Null is disallowed as a TJSON value"
 result = "error"
 
-{"example:v": null}
+{"example:b": null}
 
 -----
 name = "Null Object"

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -287,10 +287,14 @@ The following is an example of a TJSON timestamp:
 
 TJSON libraries SHOULD convert these timestamps to a native date/time type.
 
-## Boolean Values ("v")
+## Boolean Values ("b")
 
-Boolean values are identified by the "v" tag. Only the `true` and `false`
+Boolean values are identified by the "b" tag. Only the `true` and `false`
 values are allowed: `null` MUST be rejected with a parse error.
+
+The following is an example of a TJSON boolean:
+
+    {"example:b": true}
 
 ## Arrays ("A")
 

--- a/draft-tjson-spec.md
+++ b/draft-tjson-spec.md
@@ -161,23 +161,23 @@ The following is an example of a Unicode String literal in TJSON:
 
     {"example:s":"Hello, world!"}
 
-## Binary Data
+## Binary Data ("d")
 
 TJSON provides first-class support for binary data stored in multiple
 different encodings within a tagged string. Tags for binary data begin
-with the "b" character followed by an alphanumeric identifier for a
+with the "d" character followed by an alphanumeric identifier for a
 specific format.
 
-The preferred encoding is base64url ("b64"), which SHOULD be used by
+The preferred encoding is base64url ("d64"), which SHOULD be used by
 default unless another encoding is explicitly specified at serialization
 time.
 
 The base16, base32, and base64url formats are mandatory to implement for all
 TJSON parsers.
 
-### base16 ("b16")
+### base16 ("d16")
 
-Base16 literals are identified by the "b16" tag, with an associated JSON
+Base16 literals are identified by the "d16" tag, with an associated JSON
 JSON string literal value containing base16-serialized binary data.
 
 The base16 format (a.k.a. hexadecimal) is described in [@!RFC4648]. All base16
@@ -185,14 +185,14 @@ strings in TJSON MUST be lower case.
 
 The following is an example of a base16 string literal in TJSON:
 
-    {"example:b16":"48656c6c6f2c20776f726c6421"}
+    {"example:d16":"48656c6c6f2c20776f726c6421"}
 
 This decodes to an object with an "example" key whose value is the equivalent
 of the ASCII string: "Hello, world!"
 
-### base32 ("b32")
+### base32 ("d32")
 
-Base32 literals are identified by the "b32" tag, with an associated JSON
+Base32 literals are identified by the "d32" tag, with an associated JSON
 JSON string literal value containing base32-serialized binary data.
 
 The base32 format is described in [@!RFC4648]. All base32 strings in TJSON
@@ -202,14 +202,14 @@ or padding.
 
 The following is an example of a base32 string literal in TJSON:
 
-    {"example:b32":"jbswy3dpfqqho33snrscc"}
+    {"example:d32":"jbswy3dpfqqho33snrscc"}
 
 This decodes to an object with an "example" key whose value is the equivalent
 of the ASCII string: "Hello, world!"
 
-### base64url ("b64")
+### base64url ("d64")
 
-Base64url literals are identified by the "b" or "b64" tags, with an
+Base64url literals are identified by the "d" or "d64" tags, with an
 associated JSON string literal value containing base64url-serialized binary
 data.
 
@@ -217,16 +217,16 @@ The base64url format is described in [@!RFC4648]. All base64url strings in
 TJSON MUST NOT include any padding with the '=' character. TJSON parsers MUST
 reject any documents containing padded base64url strings.
 
-When serializing binary data as TJSON, encoders SHOULD use the "b" tag to
+When serializing binary data as TJSON, encoders SHOULD use the "d" tag to
 indicate binary data unless another format has been explicitly specified.
 
 The following is an example of a base64url string literal in TJSON:
 
-    {"example:b64":"SGVsbG8sIHdvcmxkIQ"}
+    {"example:d64":"SGVsbG8sIHdvcmxkIQ"}
 
-The following is the same document using the shorter "b" tag:
+The following is the same document using the shorter "d" tag:
 
-    {"example:b":"SGVsbG8sIHdvcmxkIQ"}
+    {"example:d":"SGVsbG8sIHdvcmxkIQ"}
 
 This decodes to an object with an "example" key whose value is the equivalent
 of the ASCII string: "Hello, world!"

--- a/generated/draft-tjson-spec.html
+++ b/generated/draft-tjson-spec.html
@@ -381,10 +381,10 @@
 <link href="#rfc.section.2.2" rel="Chapter" title="2.2 Root Symbol"/>
 <link href="#rfc.section.3" rel="Chapter" title="3 Extended Types"/>
 <link href="#rfc.section.3.1" rel="Chapter" title="3.1 Unicode Strings (&quot;s&quot;)"/>
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Binary Data"/>
-<link href="#rfc.section.3.2.1" rel="Chapter" title="3.2.1 base16 (&quot;b16&quot;)"/>
-<link href="#rfc.section.3.2.2" rel="Chapter" title="3.2.2 base32 (&quot;b32&quot;)"/>
-<link href="#rfc.section.3.2.3" rel="Chapter" title="3.2.3 base64url (&quot;b64&quot;)"/>
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Binary Data (&quot;d&quot;)"/>
+<link href="#rfc.section.3.2.1" rel="Chapter" title="3.2.1 base16 (&quot;d16&quot;)"/>
+<link href="#rfc.section.3.2.2" rel="Chapter" title="3.2.2 base32 (&quot;d32&quot;)"/>
+<link href="#rfc.section.3.2.3" rel="Chapter" title="3.2.3 base64url (&quot;d64&quot;)"/>
 <link href="#rfc.section.3.3" rel="Chapter" title="3.3 Integers"/>
 <link href="#rfc.section.3.3.1" rel="Chapter" title="3.3.1 Signed Integers (&quot;i&quot;)"/>
 <link href="#rfc.section.3.3.2" rel="Chapter" title="3.3.2 Unsigned Integers (&quot;u&quot;)"/>
@@ -467,10 +467,10 @@
 <li>2.2.   <a href="#rfc.section.2.2">Root Symbol</a></li>
 </ul><li>3.   <a href="#rfc.section.3">Extended Types</a></li>
 <ul><li>3.1.   <a href="#rfc.section.3.1">Unicode Strings ("s")</a></li>
-<li>3.2.   <a href="#rfc.section.3.2">Binary Data</a></li>
-<ul><li>3.2.1.   <a href="#rfc.section.3.2.1">base16 ("b16")</a></li>
-<li>3.2.2.   <a href="#rfc.section.3.2.2">base32 ("b32")</a></li>
-<li>3.2.3.   <a href="#rfc.section.3.2.3">base64url ("b64")</a></li>
+<li>3.2.   <a href="#rfc.section.3.2">Binary Data ("d")</a></li>
+<ul><li>3.2.1.   <a href="#rfc.section.3.2.1">base16 ("d16")</a></li>
+<li>3.2.2.   <a href="#rfc.section.3.2.2">base32 ("d32")</a></li>
+<li>3.2.3.   <a href="#rfc.section.3.2.3">base64url ("d64")</a></li>
 </ul><li>3.3.   <a href="#rfc.section.3.3">Integers</a></li>
 <ul><li>3.3.1.   <a href="#rfc.section.3.3.1">Signed Integers ("i")</a></li>
 <li>3.3.2.   <a href="#rfc.section.3.3.2">Unsigned Integers ("u")</a></li>
@@ -578,37 +578,37 @@
 <pre>
 {"example:s":"Hello, world!"}
 </pre>
-<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#binary-data" id="binary-data">Binary Data</a></h1>
-<p id="rfc.section.3.2.p.1">TJSON provides first-class support for binary data stored in multiple different encodings within a tagged string. Tags for binary data begin with the "b" character followed by an alphanumeric identifier for a specific format.  </p>
-<p id="rfc.section.3.2.p.2">The preferred encoding is base64url ("b64"), which SHOULD be used by default unless another encoding is explicitly specified at serialization time.  </p>
+<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#binary-data-d" id="binary-data-d">Binary Data ("d")</a></h1>
+<p id="rfc.section.3.2.p.1">TJSON provides first-class support for binary data stored in multiple different encodings within a tagged string. Tags for binary data begin with the "d" character followed by an alphanumeric identifier for a specific format.  </p>
+<p id="rfc.section.3.2.p.2">The preferred encoding is base64url ("d64"), which SHOULD be used by default unless another encoding is explicitly specified at serialization time.  </p>
 <p id="rfc.section.3.2.p.3">The base16, base32, and base64url formats are mandatory to implement for all TJSON parsers.  </p>
-<h1 id="rfc.section.3.2.1"><a href="#rfc.section.3.2.1">3.2.1.</a> <a href="#base16-b16" id="base16-b16">base16 ("b16")</a></h1>
-<p id="rfc.section.3.2.1.p.1">Base16 literals are identified by the "b16" tag, with an associated JSON JSON string literal value containing base16-serialized binary data.  </p>
+<h1 id="rfc.section.3.2.1"><a href="#rfc.section.3.2.1">3.2.1.</a> <a href="#base16-d16" id="base16-d16">base16 ("d16")</a></h1>
+<p id="rfc.section.3.2.1.p.1">Base16 literals are identified by the "d16" tag, with an associated JSON JSON string literal value containing base16-serialized binary data.  </p>
 <p id="rfc.section.3.2.1.p.2">The base16 format (a.k.a. hexadecimal) is described in <a href="#RFC4648">[RFC4648]</a>. All base16 strings in TJSON MUST be lower case.  </p>
 <p id="rfc.section.3.2.1.p.3">The following is an example of a base16 string literal in TJSON: </p>
 <pre>
-{"example:b16":"48656c6c6f2c20776f726c6421"}
+{"example:d16":"48656c6c6f2c20776f726c6421"}
 </pre>
 <p id="rfc.section.3.2.1.p.4">This decodes to an object with an "example" key whose value is the equivalent of the ASCII string: "Hello, world!" </p>
-<h1 id="rfc.section.3.2.2"><a href="#rfc.section.3.2.2">3.2.2.</a> <a href="#base32-b32" id="base32-b32">base32 ("b32")</a></h1>
-<p id="rfc.section.3.2.2.p.1">Base32 literals are identified by the "b32" tag, with an associated JSON JSON string literal value containing base32-serialized binary data.  </p>
+<h1 id="rfc.section.3.2.2"><a href="#rfc.section.3.2.2">3.2.2.</a> <a href="#base32-d32" id="base32-d32">base32 ("d32")</a></h1>
+<p id="rfc.section.3.2.2.p.1">Base32 literals are identified by the "d32" tag, with an associated JSON JSON string literal value containing base32-serialized binary data.  </p>
 <p id="rfc.section.3.2.2.p.2">The base32 format is described in <a href="#RFC4648">[RFC4648]</a>. All base32 strings in TJSON MUST be lower case, and MUST NOT include any padding with the '=' character.  TJSON parsers MUST reject any documents containing upper case base32 characters or padding.  </p>
 <p id="rfc.section.3.2.2.p.3">The following is an example of a base32 string literal in TJSON: </p>
 <pre>
-{"example:b32":"jbswy3dpfqqho33snrscc"}
+{"example:d32":"jbswy3dpfqqho33snrscc"}
 </pre>
 <p id="rfc.section.3.2.2.p.4">This decodes to an object with an "example" key whose value is the equivalent of the ASCII string: "Hello, world!" </p>
-<h1 id="rfc.section.3.2.3"><a href="#rfc.section.3.2.3">3.2.3.</a> <a href="#base64url-b64" id="base64url-b64">base64url ("b64")</a></h1>
-<p id="rfc.section.3.2.3.p.1">Base64url literals are identified by the "b" or "b64" tags, with an associated JSON string literal value containing base64url-serialized binary data.  </p>
+<h1 id="rfc.section.3.2.3"><a href="#rfc.section.3.2.3">3.2.3.</a> <a href="#base64url-d64" id="base64url-d64">base64url ("d64")</a></h1>
+<p id="rfc.section.3.2.3.p.1">Base64url literals are identified by the "d" or "d64" tags, with an associated JSON string literal value containing base64url-serialized binary data.  </p>
 <p id="rfc.section.3.2.3.p.2">The base64url format is described in <a href="#RFC4648">[RFC4648]</a>. All base64url strings in TJSON MUST NOT include any padding with the '=' character. TJSON parsers MUST reject any documents containing padded base64url strings.  </p>
-<p id="rfc.section.3.2.3.p.3">When serializing binary data as TJSON, encoders SHOULD use the "b" tag to indicate binary data unless another format has been explicitly specified.  </p>
+<p id="rfc.section.3.2.3.p.3">When serializing binary data as TJSON, encoders SHOULD use the "d" tag to indicate binary data unless another format has been explicitly specified.  </p>
 <p id="rfc.section.3.2.3.p.4">The following is an example of a base64url string literal in TJSON: </p>
 <pre>
-{"example:b64":"SGVsbG8sIHdvcmxkIQ"}
+{"example:d64":"SGVsbG8sIHdvcmxkIQ"}
 </pre>
-<p id="rfc.section.3.2.3.p.5">The following is the same document using the shorter "b" tag: </p>
+<p id="rfc.section.3.2.3.p.5">The following is the same document using the shorter "d" tag: </p>
 <pre>
-{"example:b":"SGVsbG8sIHdvcmxkIQ"}
+{"example:d":"SGVsbG8sIHdvcmxkIQ"}
 </pre>
 <p id="rfc.section.3.2.3.p.6">This decodes to an object with an "example" key whose value is the equivalent of the ASCII string: "Hello, world!" </p>
 <p id="rfc.section.3.2.3.p.7">Only the base64url format is supported. The non-URL safe form of base64 is not supported and MUST be rejected by parsers.  </p>

--- a/generated/draft-tjson-spec.html
+++ b/generated/draft-tjson-spec.html
@@ -390,7 +390,7 @@
 <link href="#rfc.section.3.3.2" rel="Chapter" title="3.3.2 Unsigned Integers (&quot;u&quot;)"/>
 <link href="#rfc.section.3.4" rel="Chapter" title="3.4 Floating Points (&quot;f&quot;)"/>
 <link href="#rfc.section.3.5" rel="Chapter" title="3.5 Timestamps (&quot;t&quot;)"/>
-<link href="#rfc.section.3.6" rel="Chapter" title="3.6 Boolean Values (&quot;v&quot;)"/>
+<link href="#rfc.section.3.6" rel="Chapter" title="3.6 Boolean Values (&quot;b&quot;)"/>
 <link href="#rfc.section.3.7" rel="Chapter" title="3.7 Arrays (&quot;A&quot;)"/>
 <link href="#rfc.section.3.8" rel="Chapter" title="3.8 Sets (&quot;S&quot;)"/>
 <link href="#rfc.section.3.9" rel="Chapter" title="3.9 Objects (&quot;O&quot;)"/>
@@ -476,7 +476,7 @@
 <li>3.3.2.   <a href="#rfc.section.3.3.2">Unsigned Integers ("u")</a></li>
 </ul><li>3.4.   <a href="#rfc.section.3.4">Floating Points ("f")</a></li>
 <li>3.5.   <a href="#rfc.section.3.5">Timestamps ("t")</a></li>
-<li>3.6.   <a href="#rfc.section.3.6">Boolean Values ("v")</a></li>
+<li>3.6.   <a href="#rfc.section.3.6">Boolean Values ("b")</a></li>
 <li>3.7.   <a href="#rfc.section.3.7">Arrays ("A")</a></li>
 <li>3.8.   <a href="#rfc.section.3.8">Sets ("S")</a></li>
 <li>3.9.   <a href="#rfc.section.3.9">Objects ("O")</a></li>
@@ -632,8 +632,12 @@
 {"example:t":"2016-10-02T07:31:51Z"}
 </pre>
 <p id="rfc.section.3.5.p.3">TJSON libraries SHOULD convert these timestamps to a native date/time type.  </p>
-<h1 id="rfc.section.3.6"><a href="#rfc.section.3.6">3.6.</a> <a href="#boolean-values-v" id="boolean-values-v">Boolean Values ("v")</a></h1>
-<p id="rfc.section.3.6.p.1">Boolean values are identified by the "v" tag. Only the <samp>true</samp> and <samp>false</samp> values are allowed: <samp>null</samp> MUST be rejected with a parse error.  </p>
+<h1 id="rfc.section.3.6"><a href="#rfc.section.3.6">3.6.</a> <a href="#boolean-values-b" id="boolean-values-b">Boolean Values ("b")</a></h1>
+<p id="rfc.section.3.6.p.1">Boolean values are identified by the "b" tag. Only the <samp>true</samp> and <samp>false</samp> values are allowed: <samp>null</samp> MUST be rejected with a parse error.  </p>
+<p id="rfc.section.3.6.p.2">The following is an example of a TJSON boolean: </p>
+<pre>
+{"example:b": true}
+</pre>
 <h1 id="rfc.section.3.7"><a href="#rfc.section.3.7">3.7.</a> <a href="#arrays-a" id="arrays-a">Arrays ("A")</a></h1>
 <p id="rfc.section.3.7.p.1">Arrays are a non-scalar and therefore use an upper case tag name as described in section 2.1.  </p>
 <p id="rfc.section.3.7.p.2">The "A" tag, with an associated JSON array value, identifies a TJSON array.  Non-scalars are parameterized by the types they contain, so fully identifying an array depends on its contents.  </p>

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -76,12 +76,12 @@ Table of Contents
        3.3.2.  Unsigned Integers ("u") . . . . . . . . . . . . . . .   7
      3.4.  Floating Points ("f") . . . . . . . . . . . . . . . . . .   8
      3.5.  Timestamps ("t")  . . . . . . . . . . . . . . . . . . . .   8
-     3.6.  Boolean Values ("v")  . . . . . . . . . . . . . . . . . .   8
+     3.6.  Boolean Values ("b")  . . . . . . . . . . . . . . . . . .   8
      3.7.  Arrays ("A")  . . . . . . . . . . . . . . . . . . . . . .   8
      3.8.  Sets ("S")  . . . . . . . . . . . . . . . . . . . . . . .   9
      3.9.  Objects ("O") . . . . . . . . . . . . . . . . . . . . . .  10
    4.  Normative References  . . . . . . . . . . . . . . . . . . . .  10
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  11
 
 1.  Introduction
 
@@ -421,11 +421,15 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
    TJSON libraries SHOULD convert these timestamps to a native date/time
    type.
 
-3.6.  Boolean Values ("v")
+3.6.  Boolean Values ("b")
 
-   Boolean values are identified by the "v" tag.  Only the "true" and
+   Boolean values are identified by the "b" tag.  Only the "true" and
    "false" values are allowed: "null" MUST be rejected with a parse
    error.
+
+   The following is an example of a TJSON boolean:
+
+                            {"example:b": true}
 
 3.7.  Arrays ("A")
 
@@ -438,10 +442,6 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
 
    Empty arrays do not require a corresponding inner type, in which case
    the inner type MAY be omitted from the type description.  However,
-   type parameters are mandatory unless the array is empty, and parsers
-   MUST reject documents missing an inner type for non-empty arrays.
-
-   The following is an example of a TJSON array containing integers:
 
 
 
@@ -449,6 +449,11 @@ Arcieri & Laurie        Expires October 17, 2017                [Page 8]
 
 Internet-Draft        TJSON Data Interchange Format           April 2017
 
+
+   type parameters are mandatory unless the array is empty, and parsers
+   MUST reject documents missing an inner type for non-empty arrays.
+
+   The following is an example of a TJSON array containing integers:
 
                      {"example:A<i>": ["1", "2", "3"]}
 
@@ -493,11 +498,6 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
 
                             {"example:S<>": []}
 
-   An empty set containing an inner type signature is also valid:
-
-                           {"example:S<i>": []}
-
-
 
 
 
@@ -505,6 +505,10 @@ Arcieri & Laurie        Expires October 17, 2017                [Page 9]
 
 Internet-Draft        TJSON Data Interchange Format           April 2017
 
+
+   An empty set containing an inner type signature is also valid:
+
+                           {"example:S<i>": []}
 
 3.9.  Objects ("O")
 
@@ -546,6 +550,18 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
               Interchange Format", RFC 7159, DOI 10.17487/RFC7159, March
               2014, <http://www.rfc-editor.org/info/rfc7159>.
 
+
+
+
+
+
+
+
+Arcieri & Laurie        Expires October 17, 2017               [Page 10]
+
+Internet-Draft        TJSON Data Interchange Format           April 2017
+
+
 Authors' Addresses
 
    Tony Arcieri
@@ -557,4 +573,44 @@ Authors' Addresses
 
 
 
-Arcieri & Laurie        Expires October 17, 2017               [Page 10]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arcieri & Laurie        Expires October 17, 2017               [Page 11]

--- a/generated/draft-tjson-spec.txt
+++ b/generated/draft-tjson-spec.txt
@@ -67,10 +67,10 @@ Table of Contents
      2.2.  Root Symbol . . . . . . . . . . . . . . . . . . . . . . .   5
    3.  Extended Types  . . . . . . . . . . . . . . . . . . . . . . .   5
      3.1.  Unicode Strings ("s") . . . . . . . . . . . . . . . . . .   5
-     3.2.  Binary Data . . . . . . . . . . . . . . . . . . . . . . .   5
-       3.2.1.  base16 ("b16")  . . . . . . . . . . . . . . . . . . .   6
-       3.2.2.  base32 ("b32")  . . . . . . . . . . . . . . . . . . .   6
-       3.2.3.  base64url ("b64") . . . . . . . . . . . . . . . . . .   6
+     3.2.  Binary Data ("d") . . . . . . . . . . . . . . . . . . . .   5
+       3.2.1.  base16 ("d16")  . . . . . . . . . . . . . . . . . . .   6
+       3.2.2.  base32 ("d32")  . . . . . . . . . . . . . . . . . . .   6
+       3.2.3.  base64url ("d64") . . . . . . . . . . . . . . . . . .   6
      3.3.  Integers  . . . . . . . . . . . . . . . . . . . . . . . .   7
        3.3.1.  Signed Integers ("i") . . . . . . . . . . . . . . . .   7
        3.3.2.  Unsigned Integers ("u") . . . . . . . . . . . . . . .   7
@@ -262,14 +262,14 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
 
                        {"example:s":"Hello, world!"}
 
-3.2.  Binary Data
+3.2.  Binary Data ("d")
 
    TJSON provides first-class support for binary data stored in multiple
    different encodings within a tagged string.  Tags for binary data
-   begin with the "b" character followed by an alphanumeric identifier
+   begin with the "d" character followed by an alphanumeric identifier
    for a specific format.
 
-   The preferred encoding is base64url ("b64"), which SHOULD be used by
+   The preferred encoding is base64url ("d64"), which SHOULD be used by
    default unless another encoding is explicitly specified at
    serialization time.
 
@@ -285,9 +285,9 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
    The base16, base32, and base64url formats are mandatory to implement
    for all TJSON parsers.
 
-3.2.1.  base16 ("b16")
+3.2.1.  base16 ("d16")
 
-   Base16 literals are identified by the "b16" tag, with an associated
+   Base16 literals are identified by the "d16" tag, with an associated
    JSON JSON string literal value containing base16-serialized binary
    data.
 
@@ -296,14 +296,14 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
 
    The following is an example of a base16 string literal in TJSON:
 
-               {"example:b16":"48656c6c6f2c20776f726c6421"}
+               {"example:d16":"48656c6c6f2c20776f726c6421"}
 
    This decodes to an object with an "example" key whose value is the
    equivalent of the ASCII string: "Hello, world!"
 
-3.2.2.  base32 ("b32")
+3.2.2.  base32 ("d32")
 
-   Base32 literals are identified by the "b32" tag, with an associated
+   Base32 literals are identified by the "d32" tag, with an associated
    JSON JSON string literal value containing base32-serialized binary
    data.
 
@@ -314,14 +314,14 @@ Internet-Draft        TJSON Data Interchange Format           April 2017
 
    The following is an example of a base32 string literal in TJSON:
 
-                  {"example:b32":"jbswy3dpfqqho33snrscc"}
+                  {"example:d32":"jbswy3dpfqqho33snrscc"}
 
    This decodes to an object with an "example" key whose value is the
    equivalent of the ASCII string: "Hello, world!"
 
-3.2.3.  base64url ("b64")
+3.2.3.  base64url ("d64")
 
-   Base64url literals are identified by the "b" or "b64" tags, with an
+   Base64url literals are identified by the "d" or "d64" tags, with an
    associated JSON string literal value containing base64url-serialized
    binary data.
 
@@ -338,17 +338,17 @@ Arcieri & Laurie        Expires October 17, 2017                [Page 6]
 Internet-Draft        TJSON Data Interchange Format           April 2017
 
 
-   When serializing binary data as TJSON, encoders SHOULD use the "b"
+   When serializing binary data as TJSON, encoders SHOULD use the "d"
    tag to indicate binary data unless another format has been explicitly
    specified.
 
    The following is an example of a base64url string literal in TJSON:
 
-                   {"example:b64":"SGVsbG8sIHdvcmxkIQ"}
+                   {"example:d64":"SGVsbG8sIHdvcmxkIQ"}
 
-   The following is the same document using the shorter "b" tag:
+   The following is the same document using the shorter "d" tag:
 
-                    {"example:b":"SGVsbG8sIHdvcmxkIQ"}
+                    {"example:d":"SGVsbG8sIHdvcmxkIQ"}
 
    This decodes to an object with an "example" key whose value is the
    equivalent of the ASCII string: "Hello, world!"

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -215,13 +215,13 @@ No other Unicode encodings are valid for TJSON strings.
 </artwork></figure>
 </section>
 
-<section anchor="binary-data" title="Binary Data">
+<section anchor="binary-data-d" title="Binary Data (&quot;d&quot;)">
 <t>TJSON provides first-class support for binary data stored in multiple
 different encodings within a tagged string. Tags for binary data begin
-with the &quot;b&quot; character followed by an alphanumeric identifier for a
+with the &quot;d&quot; character followed by an alphanumeric identifier for a
 specific format.
 </t>
-<t>The preferred encoding is base64url (&quot;b64&quot;), which SHOULD be used by
+<t>The preferred encoding is base64url (&quot;d64&quot;), which SHOULD be used by
 default unless another encoding is explicitly specified at serialization
 time.
 </t>
@@ -229,8 +229,8 @@ time.
 TJSON parsers.
 </t>
 
-<section anchor="base16-b16" title="base16 (&quot;b16&quot;)">
-<t>Base16 literals are identified by the &quot;b16&quot; tag, with an associated JSON
+<section anchor="base16-d16" title="base16 (&quot;d16&quot;)">
+<t>Base16 literals are identified by the &quot;d16&quot; tag, with an associated JSON
 JSON string literal value containing base16-serialized binary data.
 </t>
 <t>The base16 format (a.k.a. hexadecimal) is described in <xref target="RFC4648"/>. All base16
@@ -240,15 +240,15 @@ strings in TJSON MUST be lower case.
 </t>
 
 <figure align="center"><artwork align="center">
-{"example:b16":"48656c6c6f2c20776f726c6421"}
+{"example:d16":"48656c6c6f2c20776f726c6421"}
 </artwork></figure>
 <t>This decodes to an object with an &quot;example&quot; key whose value is the equivalent
 of the ASCII string: &quot;Hello, world!&quot;
 </t>
 </section>
 
-<section anchor="base32-b32" title="base32 (&quot;b32&quot;)">
-<t>Base32 literals are identified by the &quot;b32&quot; tag, with an associated JSON
+<section anchor="base32-d32" title="base32 (&quot;d32&quot;)">
+<t>Base32 literals are identified by the &quot;d32&quot; tag, with an associated JSON
 JSON string literal value containing base32-serialized binary data.
 </t>
 <t>The base32 format is described in <xref target="RFC4648"/>. All base32 strings in TJSON
@@ -260,15 +260,15 @@ or padding.
 </t>
 
 <figure align="center"><artwork align="center">
-{"example:b32":"jbswy3dpfqqho33snrscc"}
+{"example:d32":"jbswy3dpfqqho33snrscc"}
 </artwork></figure>
 <t>This decodes to an object with an &quot;example&quot; key whose value is the equivalent
 of the ASCII string: &quot;Hello, world!&quot;
 </t>
 </section>
 
-<section anchor="base64url-b64" title="base64url (&quot;b64&quot;)">
-<t>Base64url literals are identified by the &quot;b&quot; or &quot;b64&quot; tags, with an
+<section anchor="base64url-d64" title="base64url (&quot;d64&quot;)">
+<t>Base64url literals are identified by the &quot;d&quot; or &quot;d64&quot; tags, with an
 associated JSON string literal value containing base64url-serialized binary
 data.
 </t>
@@ -276,20 +276,20 @@ data.
 TJSON MUST NOT include any padding with the '=' character. TJSON parsers MUST
 reject any documents containing padded base64url strings.
 </t>
-<t>When serializing binary data as TJSON, encoders SHOULD use the &quot;b&quot; tag to
+<t>When serializing binary data as TJSON, encoders SHOULD use the &quot;d&quot; tag to
 indicate binary data unless another format has been explicitly specified.
 </t>
 <t>The following is an example of a base64url string literal in TJSON:
 </t>
 
 <figure align="center"><artwork align="center">
-{"example:b64":"SGVsbG8sIHdvcmxkIQ"}
+{"example:d64":"SGVsbG8sIHdvcmxkIQ"}
 </artwork></figure>
-<t>The following is the same document using the shorter &quot;b&quot; tag:
+<t>The following is the same document using the shorter &quot;d&quot; tag:
 </t>
 
 <figure align="center"><artwork align="center">
-{"example:b":"SGVsbG8sIHdvcmxkIQ"}
+{"example:d":"SGVsbG8sIHdvcmxkIQ"}
 </artwork></figure>
 <t>This decodes to an object with an &quot;example&quot; key whose value is the equivalent
 of the ASCII string: &quot;Hello, world!&quot;

--- a/generated/draft-tjson-spec.xml
+++ b/generated/draft-tjson-spec.xml
@@ -360,10 +360,16 @@ allow them.
 </t>
 </section>
 
-<section anchor="boolean-values-v" title="Boolean Values (&quot;v&quot;)">
-<t>Boolean values are identified by the &quot;v&quot; tag. Only the <spanx style="verb">true</spanx> and <spanx style="verb">false</spanx>
+<section anchor="boolean-values-b" title="Boolean Values (&quot;b&quot;)">
+<t>Boolean values are identified by the &quot;b&quot; tag. Only the <spanx style="verb">true</spanx> and <spanx style="verb">false</spanx>
 values are allowed: <spanx style="verb">null</spanx> MUST be rejected with a parse error.
 </t>
+<t>The following is an example of a TJSON boolean:
+</t>
+
+<figure align="center"><artwork align="center">
+{"example:b": true}
+</artwork></figure>
 </section>
 
 <section anchor="arrays-a" title="Arrays (&quot;A&quot;)">


### PR DESCRIPTION
Though described as "values" in JSON, the `v` tag feels unnatural for booleans. The "value" name in JSON name was likely chosen because `null` is grouped with `true`/`false`, so boolean would have been appropriate. When `null` is removed, it feels odd to call `true`/`false` "values".

The `d` tag is not taken. If we changed binary data to use "d" (for "data") it would free up `b` for use with booleans.

Some precedent for using "data" for this purpose: [Cap'n Proto calls binary blobs "Data"](https://capnproto.org/language.html)

Closes #48 